### PR TITLE
update readiness and liveness probe for server

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -403,7 +403,8 @@ spec:
           ports:
             - containerPort: {{ .Values.server.httpPort }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /ping
               port: {{ .Values.server.httpPort }}
             # Redash can take a while to come up initially, so we delay checks.
             initialDelaySeconds: 90
@@ -413,7 +414,7 @@ spec:
             failureThreshold: 10
           readinessProbe:
             httpGet:
-              path: /static/images/redash_icon_small.png
+              path: /ping
               port: {{ .Values.server.httpPort }}
             initialDelaySeconds: 10
             timeoutSeconds: 1


### PR DESCRIPTION
`/ping` API endpoint exists as an unauthenticated endpoint for response check. while this endpoint is not documented, it is functional. 

I feel this is a better endpoint than the redash icon static asset to check whether the server is running. 

I realised this when I started to look at https://discuss.redash.io/t/public-health-check-endpoint/6397/2 request.
