### PR TITLE
feat(gh-56): updated configuration to allow connection strings to be loaded from secrets

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -77,7 +77,13 @@ Shared environment block used across each component.
 {{- define "redash.env" -}}
 {{- if not .Values.postgresql.enabled }}
 - name: REDASH_DATABASE_URL
+  {{- if .Values.externalPostgreSQLSecret }}
+  valueFrom:
+    secretKeyRef:
+      {{- .Values.externalPostgreSQLSecret | toYaml | nindent 6 }}
+  {{- else }}
   value: {{ default "" .Values.externalPostgreSQL | quote }}
+  {{- end }}
 {{- else }}
 - name: REDASH_DATABASE_USER
   value: "{{ .Values.postgresql.postgresqlUsername }}"
@@ -95,7 +101,13 @@ Shared environment block used across each component.
 {{- end }}
 {{- if not .Values.redis.enabled }}
 - name: REDASH_REDIS_URL
+  {{- if .Values.externalRedisSecret }}
+  valueFrom:
+    secretKeyRef:
+      {{- .Values.externalRedisSecret | toYaml | nindent 6 }}
+  {{- else }}
   value: {{ default "" .Values.externalRedis | quote }}
+  {{- end }}
 {{- else }}
 - name: REDASH_REDIS_PASSWORD
   valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -347,6 +347,10 @@ scheduledWorker:
 
 # externalPostgreSQL -- External PostgreSQL configuration. To use an external PostgreSQL instead of the automatically deployed postgresql chart: set postgresql.enabled to false then uncomment and configure the externalPostgreSQL connection URL.
 # externalPostgreSQL: postgresql://user:pass@host:5432/database
+# externalPostgreSQLSecret -- Read external PostgreSQL configuration from a secret. This should point at a secret file with a single key which specifyies the connection string.
+# externalPostgreSQLSecret:
+#   name: redash-postgres
+#   key: connectionString
 
 # envSecretName -- Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
 envSecretName:
@@ -381,6 +385,10 @@ postgresql:
 
 # externalRedis -- External Redis configuration. To use an external Redis instead of the automatically deployed redis chart: set redis.enabled to false then uncomment and configure the externalRedis connection URL.
 # externalRedis: redis://user:pass@host:6379/database
+# externalRedisSecret -- Read external Redis configuration from a secret. This should point at a secret file with a single key which specifyies the connection string.
+# externalRedisSecret:
+#   name: redash-redis
+#   key: connectionString
 
 ## Configuration values for the redis dependency. This Redis instance is used by default for caching and temporary storage [ref](https://github.com/kubernetes/charts/blob/master/stable/redis/README.md)
 redis:


### PR DESCRIPTION
Resolves gh-56

It looks like the chart was a little behind on the helm-docs version... not sure what y'all prefer, but I've made the changes to match as close to the values that were previously there.