### PR TITLE
Add env var to helm chart to fix 500 internal errors

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 2.3.1
+version: 2.3.2
 appVersion: 8.0.2.b37747
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -493,6 +493,10 @@ Shared environment block used across each component.
 - name: REDASH_WEB_WORKERS
   value: {{ default  .Values.redash.webWorkers | quote }}
 {{- end }}
+{{- if .Values.redash.SQLAlchemyEnablePoolPrePing }}
+- name: SQLALCHEMY_ENABLE_POOL_PRE_PING
+  value: {{ default .Values.redash.SQLAlchemyEnablePoolPrePing | quote }}
+{{- end }}
 ## End primary Redash configuration
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -272,6 +272,12 @@ redash:
   schemaRunTableSizeCalculations: ""
   # -- `REDASH_WEB_WORKERS` value. How many processes will gunicorn spawn to handle web requests.
   # @default -- 4
+  SQLAlchemyEnablePoolPrePing: ""
+  # -- SQLALCHEMY_ENABLE_POOL_PRE_PING value, controls whether the database connection that's in the pool will be checked by pinging before being used or not.
+  # Turning this on prevents 500 Internal Server Errors that some people are facing.
+  #  This settings is related to https://github.com/getredash/redash/issues/4675 and the fix is already merged https://github.com/getredash/redash/pull/4741
+  # look here for more information: https://docs.sqlalchemy.org/en/13/core/pooling.html#sqlalchemy.pool.Pool.params.pre_ping
+  # @default -- true
   webWorkers: ""
   ## End primary Redash configuration
   # redash.existingSecret -- Name of existing secret to use instead of either the values above


### PR DESCRIPTION
As documented in the values.yaml file:

SQLALCHEMY_ENABLE_POOL_PRE_PING value, controls whether the database connection that's in the pool will be checked by pinging before being used or not.
Turning this on prevents 500 Internal Server Errors that some people are facing.
This env var is related to https://github.com/getredash/redash/issues/4675 and the fix is already merged @ https://github.com/getredash/redash/pull/4741
look here for more information: https://docs.sqlalchemy.org/en/13/core/pooling.html#sqlalchemy.pool.Pool.params.pre_ping

Default should be set to true.