### PR TITLE
Update README: redis password is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ redash:
   secretKey: $(openssl rand -base64 32)
 postgresql:
   postgresqlPassword: $(openssl rand -base64 32)
+redis:
+  password: $(echo "redash" | sha256sum)
 EOM
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ redash:
 postgresql:
   postgresqlPassword: $(openssl rand -base64 32)
 redis:
-  password: $(echo "redash" | sha256sum)
+  password: $(openssl rand -base64 32)
 EOM
 ```
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -36,6 +36,8 @@ redash:
   secretKey: $(openssl rand -base64 32)
 postgresql:
   postgresqlPassword: $(openssl rand -base64 32)
+redis:
+  password: $(openssl rand -base64 32)
 EOM
 ```
 


### PR DESCRIPTION
This is regarding Issue #71 .
It will be helpful to mention that a redis password is necessary to deploy the redash chart.