### PR TITLE
Allow upgraded ingress API versions with backwards compatibility

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 2.3.1
+version: 2.3.2
 appVersion: 8.0.2.b37747
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -543,3 +543,31 @@ Create the name of the service account to use
 
 # This ensures a random value is provided for postgresqlPassword:
 required "A secure random value for .postgresql.postgresqlPassword is required" .Values.postgresql.postgresqlPassword
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "redash.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "redash.ingress.isStable" -}}
+  {{- eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "redash.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "redash.ingress.isStable" .) "true") (and (eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -543,38 +543,3 @@ Create the name of the service account to use
 
 # This ensures a random value is provided for postgresqlPassword:
 required "A secure random value for .postgresql.postgresqlPassword is required" .Values.postgresql.postgresqlPassword
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "redash.ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
-      {{- print "networking.k8s.io/v1" -}}
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-    {{- print "networking.k8s.io/v1beta1" -}}
-  {{- else -}}
-    {{- print "extensions/v1beta1" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Return if ingress is stable.
-*/}}
-{{- define "redash.ingress.isStable" -}}
-  {{- eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
-{{- end -}}
-
-
-{{/*
-Return if ingress supports ingressClassName.
-*/}}
-{{- define "redash.ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "redash.ingress.isStable" .) "true") (and (eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
-{{- end -}}
-
-{{/*
-Return if ingress supports pathType.
-*/}}
-{{- define "redash.ingress.supportsPathType" -}}
-  {{- or (eq (include "redash.ingress.isStable" .) "true") (and (eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
-{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -571,3 +571,10 @@ Return if ingress supports ingressClassName.
 {{- define "redash.ingress.supportsIngressClassName" -}}
   {{- or (eq (include "redash.ingress.isStable" .) "true") (and (eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "redash.ingress.supportsPathType" -}}
+  {{- or (eq (include "redash.ingress.isStable" .) "true") (and (eq (include "redash.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "redash.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1
+{{- $ingressApiIsStable := eq (include "redash.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "redash.ingress.supportsIngressClassName" .) "true" -}}
+apiVersion: {{ include "redash.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -12,6 +14,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end -}}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -30,8 +35,15 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,11 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "redash.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- $ingressApiIsStable := eq (include "redash.ingress.isStable" .) "true" -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
-{{- $ingressSupportsIngressClassName := eq (include "redash.ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "redash.ingress.supportsPathType" .) "true" -}}
-apiVersion: {{ include "redash.ingress.apiVersion" . }}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
 {{- end }}
 {{- if .Values.ingress.tls }}
@@ -36,19 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
-            {{- if $ingressSupportsPathType }}
             pathType: {{ $ingressPathType }}
-            {{- end }}
             backend:
-              {{- if $ingressApiIsStable }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,9 @@
 {{- $fullName := include "redash.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressApiIsStable := eq (include "redash.ingress.isStable" .) "true" -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $ingressSupportsIngressClassName := eq (include "redash.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "redash.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "redash.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -15,8 +17,8 @@ metadata:
   {{- end }}
 spec:
 {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
-ingressClassName: {{ .Values.ingress.ingressClassName }}
-{{- end -}}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -34,6 +36,9 @@ ingressClassName: {{ .Values.ingress.ingressClassName }}
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
               service:

--- a/values.yaml
+++ b/values.yaml
@@ -339,12 +339,20 @@ ingress:
   # ingress.annotations -- Ingress annotations configuration
   annotations:
     {}
-    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx [deprecated]
     # kubernetes.io/tls-acme: "true"
+
+  # ingress.ingressClassName -- Sets the ingress controller class name to use.
+  ingressClassName: ""
+
   # ingress.hosts -- Ingress resource hostnames and path mappings
   hosts:
     - host: chart-example.local
       paths: []
+
+  #ingress.pathType -- How ingress paths should be treated.
+  pathType: Prefix
+
   # ingress.tls -- Ingress TLS configuration
   tls: []
   #  - secretName: chart-example-tls

--- a/values.yaml
+++ b/values.yaml
@@ -337,10 +337,7 @@ ingress:
   # ingress.enabled -- Enable ingress controller resource
   enabled: false
   # ingress.annotations -- Ingress annotations configuration
-  annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx [deprecated]
-    # kubernetes.io/tls-acme: "true"
+  annotations: {}
 
   # ingress.ingressClassName -- Sets the ingress controller class name to use.
   ingressClassName: ""


### PR DESCRIPTION
Allow upgraded ingress API versions with backwards compatibility.

Fixes:
https://github.com/getredash/contrib-helm-chart/issues/94
https://github.com/getredash/contrib-helm-chart/issues/77