### PR TITLE
Update readme with the defaults that worked for us

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ redash:
   cookieSecret: $(openssl rand -base64 32)
   secretKey: $(openssl rand -base64 32)
 postgresql:
+  enabled: true
+  image:
+    tag: "10.7.0-r68"
+  postgresqlUsername: redash
   postgresqlPassword: $(openssl rand -base64 32)
+  postgresqlDatabase: redash
 redis:
   password: $(openssl rand -base64 32)
 EOM


### PR DESCRIPTION
Seems like the bitnami image is broken https://github.com/bitnami/bitnami-docker-postgresql/issues/134#issuecomment-491109030.

For us, using this tag worked (and OOTB the config DIDN'T work).