### PR TITLE
Fix YAML parse: error converting YAML to JSON: when `redis.enabled` is set to `false`.

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Shared environment block used across each component.
   value: {{ .Values.postgresql.auth.database | quote }}
 {{- end -}}
 {{- if not .Values.redis.enabled }}
-{{- if not .Values.redash.selfManagedSecrets -}}
+{{- if not .Values.redash.selfManagedSecrets }}
 - name: REDASH_REDIS_URL
   {{- with .Values.externalRedisSecret }}
   valueFrom:
@@ -126,7 +126,7 @@ Shared environment block used across each component.
   value: {{ .Values.redis.master.service.ports.redis | quote }}
 - name: REDASH_REDIS_NAME
   value: {{ .Values.redis.database | quote }}
-{{ end -}}
+{{ end }}
 {{ range $key, $value := .Values.env -}}
 - name: {{ $key }}
   value: {{ $value | quote }}


### PR DESCRIPTION
When you set `redis.enabled` to `false` Helm cannot generate valid yaml. The error is:

```
Error: YAML parse error on redash/templates/hook-migrations-job.yaml: error converting YAML to JSON: yaml: line 43: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 43: mapping values are not allowed in this context
YAML parse error on redash/templates/hook-migrations-job.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:312
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:314
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.0/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.0/command.go:1115
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.0/command.go:1039
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:271
runtime.goexit
        runtime/asm_amd64.s:1695
```

The `helm template` command generates output with wrong new-lines:

```yaml
          env:
            - name: REDASH_DATABASE_URL
              valueFrom:
                secretKeyRef:
                  key: connectionString
                  name: redash- name: REDASH_REDIS_URL
              value: "redis://redis:6379/0"- name: PYTHONUNBUFFERED
              value: "0"
            - name: QUEUES
              value: "scheduled_queries,schemas"
```

This change fixes the error.
One caveat of the fix: when `redis.enabled` is set to `true` Helm adds additional new-line:

```yaml
        env:
          - name: REDASH_DATABASE_URL
            valueFrom:
              secretKeyRef:
                key: connectionString
                name: redash
          - name: REDASH_REDIS_PASSWORD
            valueFrom:
              secretKeyRef:
                name: redash-redis
                key: redis-password
          - name: REDASH_REDIS_HOSTNAME
            value: redash-redis-master
          - name: REDASH_REDIS_PORT
            value: "6379"
          - name: REDASH_REDIS_NAME
            value: "0"

          ## Start primary Redash configuration
```

So maybe a better fix exists.