### PR TITLE
Add variables, templating & fix formatting

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Shared environment block used across each component.
   value: {{ .Values.postgresql.auth.database | quote }}
 {{- end -}}
 {{- if not .Values.redis.enabled }}
-{{- if not .Values.redash.selfManagedSecrets -}}
+{{- if not .Values.redash.selfManagedSecrets }}
 - name: REDASH_REDIS_URL
   {{- with .Values.externalRedisSecret }}
   valueFrom:
@@ -126,11 +126,11 @@ Shared environment block used across each component.
   value: {{ .Values.redis.master.service.ports.redis | quote }}
 - name: REDASH_REDIS_NAME
   value: {{ .Values.redis.database | quote }}
-{{ end -}}
-{{ range $key, $value := .Values.env -}}
+{{- end }}
+{{- range $key, $value := .Values.env }}
 - name: {{ $key }}
   value: {{ $value | quote }}
-{{ end -}}
+{{- end }}
 ## Start primary Redash configuration
 {{- if not .Values.redash.selfManagedSecrets }}
 {{- if or .Values.redash.secretKey .Values.redash.existingSecret }}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -523,6 +523,9 @@ app.kubernetes.io/component: {{ . }}worker
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ tpl (toYaml .Values.commonLabels) . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -15,7 +15,11 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}"
-      labels: {{ include "redash.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- with .Values.migrations.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- with .Values.migrations.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -21,7 +21,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.migrations.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -21,8 +21,8 @@ spec:
         {{- with .Values.scheduler.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- if .Values.scheduler.podAnnotations }}
-      annotations: {{ toYaml .Values.scheduler.podAnnotations | nindent 8 }}
+      {{- with .Values.scheduler.podAnnotations }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with .Values.imagePullSecrets -}}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -16,11 +16,11 @@ spec:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: server
-        {{- if .Values.server.podLabels }}
-        {{- tpl (toYaml .Values.server.podLabels) $ | nindent 8 }}
+        {{- with .Values.server.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.server.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with .Values.imagePullSecrets -}}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -13,12 +13,13 @@ spec:
     matchLabels: {{ include "redash.selectorLabels" $context | nindent 6 }}
   template:
     metadata:
-      labels: {{ include "redash.selectorLabels" $context | nindent 8 }}
-      {{- if $workerConfig.podLabels }}
-      {{ tpl (toYaml $workerConfig.podLabels) $ | nindent 8 }}
-      {{- end }}
-      {{- with $workerConfig.podAnnotations -}}
-      annotations: {{ toYaml . | nindent 8 }}
+      labels:
+        {{- include "redash.selectorLabels" $context | nindent 8 }}
+        {{- with $workerConfig.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with $workerConfig.podAnnotations }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with $.Values.imagePullSecrets -}}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -29,6 +29,9 @@ volumes: []
 # volumeMounts -- Redash global volume mounts configuration - applied to all containers
 volumeMounts: []
 
+# commonLabels -- Redash global labels -- applied to all objects
+commonLabels: {}
+
 ## Service account and security context configuration
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -552,6 +552,9 @@ migrations:
   # migrations.podAnnotations -- Annotations for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
   podAnnotations: {}
 
+  # migrations.podLabels -- Labels for migration pod [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  podLabels: {}
+
 # externalPostgreSQL -- External PostgreSQL configuration. To use an external PostgreSQL instead of the automatically deployed postgresql chart: set postgresql.enabled to false then uncomment and configure the externalPostgreSQL connection URL (e.g. postgresql://user:pass@host:5432/database)
 externalPostgreSQL:
 # externalPostgreSQLSecret -- Read external PostgreSQL configuration from a secret. This should point at a secret file with a single key which specifies the connection string.


### PR DESCRIPTION
## What/Why ?
This PR contains several modest bugfixes & improvements for better customization capabilities.
cf details in each individual commit message (they are pretty autonomous).

## Notes
### About 1st commit `Fix formatting of 'redash.env' function`:
It's about fixing a bug in the chart for one specific (non default) use-case: when we using an external postgres + redis.
Basically like this (on master branch) :
```
$ helm template --set postgresql.enabled=false,redis.enabled=false,externalPostgreSQL=pgConnectionString,externalRedis=redisConnectionString .

Error: YAML parse error on redash/templates/hook-migrations-job.yaml: error converting YAML to JSON: yaml: line 40: block sequence entries are not allowed in this context
```

And with the `--debug` option, we can see the issue in the generated yamls:
```
[...]
       env:
          - name: REDASH_DATABASE_URL
            value: "pgConnectionString"- name: REDASH_REDIS_URL
            value: "redisConnectionString"## Start primary Redash configuration
          - name: REDASH_SECRET_KEY
            valueFrom:
              secretKeyRef:
                name: release-name-redash
                key: secretKey
```
=> missing new lines

Thus my 1st commit that ensure proper newlines are in place.

NB: I'm seeing just now that a PR already exists for (part of) this issue: https://github.com/getredash/contrib-helm-chart/pull/176
I recommend to keep "my" version, because I cover both cases: postgres & redis, not just redis.


### About all commits
I compared the generated manifests (using chart's default values) between the "before" and "after" my PR, cf: `helm template .`
=> no change (except some white-spaces at the end of some lines)

So, it shouldn't create any regression 😃 