### PR TITLE
Fix typo in redash.env template

### DIFF
--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 3.1.0-alpha6
+version: 3.1.0-alpha7
 appVersion: 24.04.0-dev-b8718551048.32
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -459,7 +459,7 @@ Shared environment block used across each component.
 {{- end }}
 {{- with .Values.redash.jwtAuthHeaderName }}
 - name: REDASH_JWT_AUTH_HEADER_NAME
-  value: {{ .quote }}
+  value: {{ quote . }}
 {{- end }}
 {{- with .Values.redash.featureShowQueryResultsCount }}
 - name: REDASH_FEATURE_SHOW_QUERY_RESULTS_COUNT


### PR DESCRIPTION
This caused the following error during rendering:
```
helm.go:84: [debug] template: redash/templates/worker-deployment.yaml:51:14: executing "redash/templates/worker-deployment.yaml" at <include "redash.env" $envCtx>: error calling include: template: redash/templates/_helpers.tpl:462:12: executing "redash.env" at <.quote>: can't evaluate field quote in type string
```