### PR TITLE
chore(dependencies): add better support for fullnameOverride

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -50,14 +50,14 @@ Create a default fully qualified scheduler name.
 Create a default fully qualified postgresql name.
 */}}
 {{- define "redash.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{ template "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
 {{- end -}}
 
 {{/*
 Create a default fully qualified redis name.
 */}}
 {{- define "redash.redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "redis-master" | trunc 63 | trimSuffix "-" -}}
+{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}
 {{- end -}}
 
 {{/*
@@ -91,7 +91,7 @@ Shared environment block used across each component.
 - name: REDASH_DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Release.Name }}-postgresql
+      name: {{ include "redash.fullname" . }}-postgresql
       key: password
 - name: REDASH_DATABASE_HOSTNAME
   value: {{ include "redash.postgresql.fullname" . }}
@@ -117,7 +117,7 @@ Shared environment block used across each component.
     {{- with .Values.redis.existingSecret }}
       name: {{ . }}
     {{- else }}
-      name: {{ .Release.Name }}-redis
+      name: {{ include "redash.fullname" . }}-redis
     {{- end }}
       key: redis-password
 - name: REDASH_REDIS_HOSTNAME

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-migrations"
+  name: "{{ include "redash.fullname" . }}-migrations"
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrations
@@ -14,7 +14,7 @@ spec:
   ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
   template:
     metadata:
-      name: "{{ .Release.Name }}"
+      name: "{{ include "redash.fullname" . }}"
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
         {{- with .Values.migrations.podLabels }}


### PR DESCRIPTION
Hi,

As far as I can tell, dependencies of the chart currently do not properly support `fullnameOverride`.

* Use proper host names ([postgresql](charts/redash/templates/_helpers.tpl#53), [redis](charts/redash/templates/_helpers.tpl#60))

Given the following `values-local.yaml` file, and helm install command `helm install redash-euw3 . -f values.yaml -f values-local.yaml`:

```yaml
fullnameOverride: redash

redis:
  fullnameOverride: redash-redis

postgresql:
  fullnameOverride: redash-postgresql
```

The deployment environment variables will contain the wrong hosts for both redis and postgres:

```yaml
REDASH_DATABASE_HOSTNAME:  redash-euw3-postgresql
REDASH_REDIS_HOSTNAME:     redash-euw3-redis-master
```

Since Helm 3.7 (released August 31, 2021) it's possible to invoke the subchart's named templates that we can use to match the service names. Those changes will not support postgres replication mode, nor redis sentinel, but I feel like those are not currently supported anyway.

* Use proper secret references ([postgresql](charts/redash/templates/_helpers.tpl#94), [redis](charts/redash/templates/_helpers.tpl#120))

Given the same `values-local.yaml` file, secret references will be wrong too. Templates are using the `{{ include "redash.fullname" . }}-` prefix which will not match any existing secret in case `fullnameOverride` is set for `redash`.

```yaml
NAME                                     READY   STATUS                       RESTARTS   AGE
redash-567487fc4b-zzprc                  0/1     CreateContainerConfigError   0          2s
redash-adhocworker-6c587f47cb-fzd6h      0/1     CreateContainerConfigError   0          2s
redash-euw3-migrations-624js             0/1     CreateContainerConfigError   0          2s
redash-genericworker-648bddc87b-h5txc    0/1     CreateContainerConfigError   0          2s
redash-postgresql-0                      0/1     ContainerCreating            0          2s
redash-redis-master-0                    0/1     ContainerCreating            0          2s
redash-scheduledworker-cd959c959-b5q8s   0/1     CreateContainerConfigError   0          2s
redash-scheduler-7dcd4cbf46-2zjv6        0/1     CreateContainerConfigError   0          2s
```

The error will look like `Warning  Failed     4m28s (x12 over 6m38s)  kubelet            Error: secret "redash-euw3-postgresql" not found`.

* Use fullnameOverride for the migration job ([hook](charts/redash/templates/hook-migrations-job.yaml#4))

Finally, the migration job hook uses the `{{ .Release.Name }}-` prefix as a name instead of `{{ include "redash.fullname" . }}-`.

Those changes do not address any open issue. It's just a problem I ran into. What do you think of those changes ?

Thanks in advance for reviewing.