### PR TITLE
fix(worker): fix imagePullSecrets templating

### DIFF
--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       {{ with $.Values.imagePullSecrets -}}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{- end -}}
+      {{ end -}}
       serviceAccountName: {{ include "redash.serviceAccountName" $context }}
       securityContext: {{ toYaml $workerConfig.podSecurityContext | nindent 8 }}
       {{- with concat $.Values.initContainers $workerConfig.initContainers }}


### PR DESCRIPTION
Hi,

`imagePullSecrets` templating goes wrong on master at the moment. Some spaces should not be removed.

Current behavior:

```yaml
imagePullSecrets:
        - name: my-secret serviceAccountName: redash
```

Expected behavior, after fix:

```yaml
imagePullSecrets:
        - name: my-secret
serviceAccountName: redash
```

Thanks in advance for reviewing.