### PR TITLE
Feature/topologySpreadConstraints ADD

### DIFF
--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -62,6 +62,9 @@ spec:
       {{- with .Values.migrations.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.migrations.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.migrations.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with .Values.migrations.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -67,6 +67,9 @@ spec:
       {{- with .Values.scheduler.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.scheduler.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.scheduler.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with .Values.scheduler.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -71,6 +71,9 @@ spec:
       {{- with .Values.server.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.server.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with .Values.server.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -63,6 +63,9 @@ spec:
       {{- with $workerConfig.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.$workerConfig.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.$workerConfig.topologySpreadConstraints | indent 8 }}
+      {{- end }}
       {{- with $workerConfig.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -337,6 +337,9 @@ server:
   # server.nodeSelector -- Node labels for server pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # server.topologySpreadConstraints -- Default topologySpreadConstraints for server pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: {}
+
   # server.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -435,6 +438,9 @@ worker:
   # worker.nodeSelector -- Default node labels for worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # worker.topologySpreadConstraints -- Default topologySpreadConstraints for worker pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: {}
+
   # worker.tolerations -- Default tolerations for worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -505,6 +511,9 @@ scheduler:
   # scheduler.nodeSelector -- Node labels for scheduler pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # scheduler.topologySpreadConstraints -- Default topologySpreadConstraints for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: {}
+
   # scheduler.tolerations -- Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -554,6 +563,9 @@ migrations:
 
   # migrations.nodeSelector -- Node labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
+
+  # migrations.topologySpreadConstraints -- Default topologySpreadConstraints for migrations pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: {}
 
   # migrations.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []


### PR DESCRIPTION
Hi,

I need topologySpreadConstraints, so I create PR on this repo

about topologySpreadConstraints, you can visit [here](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)

> You can use topology spread constraints to control how [Pods](https://kubernetes.io/docs/concepts/workloads/pods/) are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. This can help to achieve high availability as well as efficient resource utilization.

I would be useful for other users.