### PR TITLE
fix: honor postgres existing secret and keys

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -91,8 +91,8 @@ Shared environment block used across each component.
 - name: REDASH_DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Release.Name }}-postgresql
-      key: password
+      name: {{ .Values.postgresql.auth.existingSecret | default (printf "%s-postgresql" .Release.Name) }}
+      key: {{ ternary .Values.postgresql.auth.secretKeys.userPasswordKey "password" (ne .Values.postgresql.auth.existingSecret "") }}
 - name: REDASH_DATABASE_HOSTNAME
   value: {{ include "redash.postgresql.fullname" . }}
 - name: REDASH_DATABASE_PORT


### PR DESCRIPTION
default behavior remains but if there is a postgres existing secret use that along with the specified userPasswordKey