### PR TITLE
chore(*): upgrade to 25.1.0

### DIFF
--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: redash
-version: 3.1.0-alpha9
-appVersion: 24.04.0-dev-b8718551048.32
+version: 4.0.0-alpha1
+appVersion: 25.1.0
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:
   - redash

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -126,6 +126,8 @@ Shared environment block used across each component.
   value: {{ .Values.redis.master.service.ports.redis | quote }}
 - name: REDASH_REDIS_NAME
   value: {{ .Values.redis.database | quote }}
+- name: REDASH_REDIS_URL
+  value: "redis://:$(REDASH_REDIS_PASSWORD)@$(REDASH_REDIS_HOSTNAME):$(REDASH_REDIS_PORT)/$(REDASH_REDIS_NAME)"
 {{- end }}
 {{- range $key, $value := .Values.env }}
 - name: {{ $key }}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -3,7 +3,7 @@
 image:
   registry: docker.io
   # image.repo -- Redash image name used for server and worker pods
-  repo: redash/preview
+  repo: redash/redash
   # image.tag -- Redash image [tag](https://hub.docker.com/r/redash/redash/tags)
   tag:
   # image.pullPolicy - Image pull policy


### PR DESCRIPTION
This PR aims at upgrading the chart to the latest 25.1.0 release. It introduces a new environment variable `REDASH_REDIS_URL` as creation of it at runtime [was removed](https://github.com/getredash/redash/pull/6967/files#diff-e81142671f0a25b82f4b554539412c6df3ae13fade65443705780549f0485591L5). See https://github.com/getredash/redash/issues/7072 for more details.

Thanks in advance for reviewing.