### PR TITLE
Add migrations.extraContainers option

### DIFF
--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | migrations.ttlSecondsAfterFinished | int | `600` | ttl for install job [ref](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) |
 | migrations.volumeMounts | list | `[]` | volume mounts for migrations pods |
 | migrations.volumes | list | `[]` | volumes that will be mounted to migrations pods only |
+| migrations.extraContainers | object | `{}` | Extra containers for migrations pod assignment |
 | nameOverride | string | `""` |  |
 | postgresql.auth.database | string | `"redash"` | PostgreSQL database name (when postgresql chart enabled) |
 | postgresql.auth.password | string | `nil` | REQUIRED: PostgreSQL password for redash user (when postgresql chart enabled) |
@@ -218,6 +219,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | scheduler.tolerations | list | `[]` | Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | scheduler.volumeMounts | list | `[]` | VolumeMounts for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scheduler.volumes | list | `[]` | Volumes for scheduler pod  assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
+| scheduler.extraContainers | object | `{}` | Extra containers for scheduler pod assignment |
 | server.affinity | object | `{}` | Affinity for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | server.env | object | `{}` | Redash server specific environment variables Don't use this for variables that are in the configuration above, however. |
 | server.httpPort | int | `5000` | Server container port (only useful if you are using a customized image) |
@@ -234,6 +236,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | server.tolerations | list | `[]` | Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | server.volumeMounts | list | `[]` | VolumeMounts for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | server.volumes | list | `[]` | Volumes for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
+| server.extraContainers | object | `{}` | Extra containers for server pod assignment |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.externalTrafficPolicy | string | `""` |  |
 | service.loadBalancerIP | string | `nil` | Specific IP address to use for cloud providers such as Azure Kubernetes Service [ref](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) |
@@ -257,6 +260,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | worker.tolerations | list | `[]` | Default tolerations for worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | worker.volumeMounts | list | `[]` | Default VolumeMounts for worker pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | worker.volumes | list | `[]` | Default volumes for pod worker assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
+| worker.extraContainers | object | `{}` | Extra containers for worker pod assignment |
 | workers.adhoc.env | object | `{"QUEUES":"queries","WORKERS_COUNT":2}` | Redash ad-hoc worker specific environment variables. |
 | workers.generic.env | object | `{"QUEUES":"periodic,emails,default","WORKERS_COUNT":1}` | Redash generic worker specific environment variables. |
 | workers.scheduled.env | object | `{"QUEUES":"scheduled_queries,schemas","WORKERS_COUNT":1}` | Redash scheduled worker specific environment variables. |

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -39,24 +39,24 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: {{ include "redash.name" . }}-server
-          securityContext: {{ toYaml .Values.migrations.securityContext | nindent 10 }}
+          securityContext: {{ toYaml .Values.migrations.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - create_db
           env:
           {{- $envCtx := mergeOverwrite (deepCopy .) (dict "Values" (dict "env" .Values.migrations.env)) -}}
-          {{- include "redash.env" $envCtx | nindent 10 }}
+          {{- include "redash.env" $envCtx | nindent 12 }}
           {{- if (include "redash.envFrom" .) }}
           envFrom:
-          {{- include "redash.envFrom" . | nindent 10 }}
+          {{- include "redash.envFrom" . | nindent 12 }}
           {{- end}}
           {{- with .Values.migrations.resources }}
-          resources: {{ toYaml . | nindent 10 }}
+          resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- $volumeMounts := concat .Values.volumeMounts .Values.migrations.volumeMounts }}
           {{- with $volumeMounts }}
-          volumeMounts: {{ toYaml . | nindent 10 }}
+          volumeMounts: {{ toYaml . | nindent 12 }}
           {{- end }}
       {{- $volumes := concat .Values.volumes .Values.migrations.volumes -}}
       {{- with $volumes }}

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -35,26 +35,29 @@ spec:
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ include "redash.name" . }}-server
-        securityContext: {{ toYaml .Values.migrations.securityContext | nindent 10 }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args:
-          - create_db
-        env:
-        {{- $envCtx := mergeOverwrite (deepCopy .) (dict "Values" (dict "env" .Values.migrations.env)) -}}
-        {{- include "redash.env" $envCtx | nindent 10 }}
-        {{- if (include "redash.envFrom" .) }}
-        envFrom:
-        {{- include "redash.envFrom" . | nindent 10 }}
-        {{- end}}
-        {{- with .Values.migrations.resources }}
-        resources: {{ toYaml . | nindent 10 }}
+        {{- with .Values.migrations.extraContainers -}}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- $volumeMounts := concat .Values.volumeMounts .Values.migrations.volumeMounts }}
-        {{- with $volumeMounts }}
-        volumeMounts: {{ toYaml . | nindent 10 }}
-        {{- end }}
+        - name: {{ include "redash.name" . }}-server
+          securityContext: {{ toYaml .Values.migrations.securityContext | nindent 10 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - create_db
+          env:
+          {{- $envCtx := mergeOverwrite (deepCopy .) (dict "Values" (dict "env" .Values.migrations.env)) -}}
+          {{- include "redash.env" $envCtx | nindent 10 }}
+          {{- if (include "redash.envFrom" .) }}
+          envFrom:
+          {{- include "redash.envFrom" . | nindent 10 }}
+          {{- end}}
+          {{- with .Values.migrations.resources }}
+          resources: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- $volumeMounts := concat .Values.volumeMounts .Values.migrations.volumeMounts }}
+          {{- with $volumeMounts }}
+          volumeMounts: {{ toYaml . | nindent 10 }}
+          {{- end }}
       {{- $volumes := concat .Values.volumes .Values.migrations.volumes -}}
       {{- with $volumes }}
       volumes: {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
## What
add migrations.extraContainers option.
It looks that this option was missed in 707adce8001c161495b7fa01f48a12121c9ca195.

## Why
Because I want to use Cloud SQL Proxy as a sidecar on the migrations job pod, and when I deployed the helm chart to my cluster, it blamed that migration job couldn't access to Cloud SQL because of lacking the proxy sidecar.