### PR TITLE
Allow configuration of SQLALCHEMY_ENABLE_POOL_PRE_PING

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -497,6 +497,10 @@ Shared environment block used across each component.
 - name: REDASH_WEB_WORKERS
   value: {{ quote . }}
 {{- end }}
+{{- if .Values.redash.sqlAlchemyEnablePoolPrePing }}
+- name: SQLALCHEMY_ENABLE_POOL_PRE_PING
+  value: {{ default .Values.redash.sqlAlchemyEnablePoolPrePing | quote }}
+{{- end }}
 ## End primary Redash configuration
 {{- end -}}
 


### PR DESCRIPTION
This utilizes the existing chart value `sqlAlchemyEnablePoolPrePing` to set the `SQLALCHEMY_ENABLE_POOL_PRE_PING` environment variable in `_helpers.tpl`.

This is a reproduction of #95, which appears to have been lost between then and now.