### PR TITLE
Fix typos in README and other documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 - Final release to support Redash v8.x
 - Redis password is now required
 - Kubernetes minimum version increased to v19.x
-- Helm 2 depreciated, will be removed in a future version
+- Helm 2 deprecated, will be removed in a future version
 - Supports stable Ingress API
 - Add support for SQL Alchemy pool pre-ping configuration
 - Add support for configurable worker pod labels
@@ -244,7 +244,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 ## 2.3.0
 
 - Added externalPostgreSQLSecret / externalRedisSecret
-- Depreciated envSecretName (plan to remove in 3.0.0 chart)
+- Deprecated envSecretName (plan to remove in 3.0.0 chart)
 - Updated docs to make defaults clearer
 
 ## 2.2.0
@@ -278,7 +278,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 ## 1.2.0
 
 - Upgrade Redash to 8.0.2.b37747
-- Upgrade PostgreSQL chart (the old version used depreciated APIs) and image tag
+- Upgrade PostgreSQL chart (the old version used deprecated APIs) and image tag
 - Upgrade Redis chart
 
 ## 1.1.0

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -16,7 +16,7 @@ Current chart version is `3.2.0`
 
 - At least 3 GB of RAM available on your cluster
 - Kubernetes 1.31+ - chart is tested with latest 4 stable versions (1.31-1.34)
-- Helm 3 (Helm 2 depreciated)
+- Helm 3 (Helm 2 deprecated)
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -49,7 +49,7 @@ Install the chart:
 $ helm upgrade --install -f my-values.yaml my-release redash/redash
 ```
 
-The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
+The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -387,21 +387,21 @@ If you prefer manual control:
 - The Redash version is updated from v8 to v10 (v9 never had a stable release)
 - The upgrade should be automatic, but please test on a staging environment first!
 - There are now additional "genericworker" and "scheduler" deployments, with associated configuration in values.yaml
-- 3.x and higher will not run with Redash v8 - if you have overriden the image you will need to update that
+- 3.x and higher will not run with Redash v8 - if you have overridden the image you will need to update that
 - This chart now requires Kubernetes 1.19+
-- Helm 2 is now depreciated and support will be removed in a future version
+- Helm 2 is now deprecated and support will be removed in a future version
 
 ### From 1.x to 2.x
 
 - There are 3 required secrets (see above) that must now be specified in your release
-- The server.env is now depreciated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
+- The server.env is now deprecated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
 
 ### From pre-release to 1.x
 
 - The values.yaml structure has several changes
 - The Redash, PostgreSQL and Redis versions have all been updated
 - Due to these changes you will likely need to dump the database and reload it into a fresh install
-- The chart now has it's own repo: https://getredash.github.io/contrib-helm-chart/
+- The chart now has its own repo: https://getredash.github.io/contrib-helm-chart/
 
 ## License
 

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -16,7 +16,7 @@ Current chart version is `{{ template "chart.version" . }}`
 
 - At least 3 GB of RAM available on your cluster
 - Kubernetes 1.19+ - chart is tested with latest 3 stable versions
-- Helm 3 (Helm 2 depreciated)
+- Helm 3 (Helm 2 deprecated)
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -49,7 +49,7 @@ Install the chart:
 $ helm upgrade --install -f my-values.yaml my-release redash/redash
 ```
 
-The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
+The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -103,21 +103,21 @@ Below are notes on manual configuration changes or steps needed for major chart 
 - The Redash version is updated from v8 to v10 (v9 never had a stable release)
 - The upgrade should be automatic, but please test on a staging environment first!
 - There are now additional "genericworker" and "scheduler" deployments, with associated configuration in values.yaml
-- 3.x and higher will not run with Redash v8 - if you have overriden the image you will need to update that 
+- 3.x and higher will not run with Redash v8 - if you have overridden the image you will need to update that
 - This chart now requires Kubernetes 1.19+
-- Helm 2 is now depreciated and support will be removed in a future version
+- Helm 2 is now deprecated and support will be removed in a future version
 
 ### From 1.x to 2.x
 
 - There are 3 required secrets (see above) that must now be specified in your release
-- The server.env is now depreciated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
+- The server.env is now deprecated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
 
 ### From pre-release to 1.x
 
 - The values.yaml structure has several changes
 - The Redash, PostgreSQL and Redis versions have all been updated
 - Due to these changes you will likely need to dump the database and reload it into a fresh install
-- The chart now has it's own repo: https://getredash.github.io/contrib-helm-chart/
+- The chart now has its own repo: https://getredash.github.io/contrib-helm-chart/
 
 ## License
 

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -365,7 +365,7 @@ service:
   loadBalancerIP:
   # service.type -- Kubernetes Service type
   type: ClusterIP
-  # service.externalTraffucPolicy -- external traffic policy for Load Balancer
+  # service.externalTrafficPolicy -- external traffic policy for Load Balancer
   externalTrafficPolicy: ""
   # service.port -- Service external port
   port: 80
@@ -411,7 +411,7 @@ workers:
       QUEUES: periodic,emails,default
       WORKERS_COUNT: 1
 
-## Common worker configuration, which can be overidden for each worker at workers.<workerName>
+## Common worker configuration, which can be overridden for each worker at workers.<workerName>
 worker:
   # worker.replicaCount -- Default number of worker pods to run
   replicaCount: 1
@@ -579,7 +579,7 @@ externalPostgreSQLSecret:
   # name: redash-postgres
   # key: connectionString
 
-# envSecretName -- DEPRECIATED, use externalPostgreSQLSecret/externalRedisSecret instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
+# envSecretName -- DEPRECATED, use externalPostgreSQLSecret/externalRedisSecret instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
 # envSecretName:
 
 ## Configuration values for the postgresql dependency. This PostgreSQL instance is used by default for all Redash state storage [ref](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md)


### PR DESCRIPTION
I have fixed various typographical errors in `README.md`, `CHANGELOG.md`, `charts/redash/README.md`, `charts/redash/README.md.gotmpl`, and `charts/redash/values.yaml`.

Key corrections:
- Changed "depreciated" to "deprecated".
- Changed "overriden" and "overidden" to "overridden".
- Changed "it's own" to "its own".
- Changed "traffuc" to "traffic".
- Removed a duplicated "and".

---
*PR created automatically by Jules for task [6018639066424520126](https://jules.google.com/task/6018639066424520126) started by @shubhamg931*