### PR TITLE
Fixes imagePullSecrets in worker-deployment

### DIFF
--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 4.0.1
+version: 4.0.2
 appVersion: 25.8.0
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -25,9 +25,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with .Values.imagePullSecrets -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.scheduler.podSecurityContext | nindent 8 }}
       {{- $initContainers := concat .Values.initContainers .Values.scheduler.initContainers }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -23,9 +23,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with .Values.imagePullSecrets -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.server.podSecurityContext | nindent 8 }}
       {{- $initContainers := concat .Values.initContainers .Values.server.initContainers }}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -22,9 +22,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with $.Values.imagePullSecrets -}}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{- end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" $context }}
       securityContext: {{ toYaml $workerConfig.podSecurityContext | nindent 8 }}
       {{- with concat $.Values.initContainers $workerConfig.initContainers }}


### PR DESCRIPTION
The template file had `{{- end -}}` that rendered an error when using imagePullSecrets: `mapping values are not allowed in this context`. Removing the extra hyphen made the template render correctly. Updated the server and scheduler templates to keep that block consistent with the other `{{ when }}` blocks in the files.