### PR TITLE
fix: add worker component to selector labels

### DIFF
--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -516,9 +516,6 @@ Common labels
 {{- define "redash.labels" -}}
 helm.sh/chart: {{ include "redash.chart" . }}
 {{ include "redash.selectorLabels" . }}
-{{- with .workerName }}
-app.kubernetes.io/component: {{ . }}worker
-{{- end }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
@@ -534,6 +531,9 @@ Selector labels
 {{- define "redash.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "redash.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .workerName }}
+app.kubernetes.io/component: {{ . }}worker
+{{- end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## Summary

- Move the worker component label into `redash.selectorLabels`.
- Ensure each worker Deployment selector includes a distinct `app.kubernetes.io/component` label.
- Keep worker metadata labels and pod template labels consistent through the shared helper.

## Why

The worker template renders one Deployment per entry in `.Values.workers`, but `redash.selectorLabels` only included the chart name and release instance. As a result, `adhocworker`, `genericworker`, and `scheduledworker` rendered identical `spec.selector.matchLabels` values and could select each other's Pods.

This appears to be a small follow-up from the worker template consolidation in #163, which successfully removed duplication but left the worker component label outside the shared selector helper.

This change makes the worker-specific component label part of the selector labels whenever `workerName` is present in the template context.

## Validation

```console
$ helm dependency build charts/redash
$ helm lint charts/redash
==> Linting charts/redash

1 chart(s) linted, 0 chart(s) failed

$ helm template test charts/redash
```

Rendered worker labels now match across Deployment metadata, selectors, and Pod templates:

```text
test-redash-adhocworker      adhocworker      adhocworker      adhocworker
test-redash-genericworker    genericworker    genericworker    genericworker
test-redash-scheduledworker  scheduledworker  scheduledworker  scheduledworker
```
