### PR TITLE
Update supported Kubernetes versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31
-          - v1.32
           - v1.33
           - v1.34
+          - v1.35
+          - v1.36
     runs-on: ubuntu-22.04
     steps:
       - uses: medyagh/setup-minikube@v0.0.21

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -15,7 +15,7 @@ Current chart version is `3.2.0`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.31+ - chart is tested with latest 4 stable versions (1.31-1.34)
+- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
 - Helm 3 (Helm 2 depreciated)
 - PV provisioner support in the underlying infrastructure
 

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -15,7 +15,7 @@ Current chart version is `{{ template "chart.version" . }}`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.19+ - chart is tested with latest 3 stable versions
+- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
 - Helm 3 (Helm 2 depreciated)
 - PV provisioner support in the underlying infrastructure
 


### PR DESCRIPTION
## Summary
- test the chart on Kubernetes 1.33, 1.34, 1.35, and 1.36
- update the chart prerequisites to match the CI matrix
