### PR TITLE
Consolidate PRs #209-#214 into 4.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.31
-          - v1.32
           - v1.33
           - v1.34
+          - v1.35
+          - v1.36
     runs-on: ubuntu-22.04
     steps:
       - uses: medyagh/setup-minikube@v0.0.21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,16 @@ jobs:
               env:
                 WORKERS_COUNT: 1
           EOM
-          helm upgrade --install redash . --wait --timeout 10m -f test-values.yaml
+          helm upgrade --install redash . --wait --timeout 5m -f test-values.yaml
           sleep 10
           helm test redash
           helm delete redash
-          helm upgrade --install redashup . --wait --timeout 10m -f test-values.yaml
+          helm upgrade --install redashup . --wait --timeout 5m -f test-values.yaml
           kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
           sleep 10
           helm test redashup
           kubectl delete pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=test-connection"
-          helm upgrade --install redashup . --wait --reset-values --timeout 10m -f test-values.yaml
+          helm upgrade --install redashup . --wait --reset-values --timeout 5m -f test-values.yaml
           kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
           sleep 10
           helm test redashup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,34 @@ on:
     branches:
       - master
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: azure/setup-helm@v4
+      - name: lint and render the chart
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+          cd charts/redash
+          helm dependency build .
+          helm lint .
+          helm template test . > /dev/null
+          helm template test . --set server.knative.enabled=true > /dev/null
   test-on-minikube:
     if: github.event_name == 'pull_request'
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         k8s:
           - v1.31
@@ -21,6 +44,8 @@ jobs:
       - uses: medyagh/setup-minikube@v0.0.21
         with:
           kubernetes-version: ${{ matrix.k8s }}
+          cpus: 4
+          memory: 8192
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
@@ -31,7 +56,6 @@ jobs:
           helm repo update
           cd charts/redash
           helm dependency build .
-          helm lint .
           cat > test-values.yaml <<- EOM
             redash:
               cookieSecret: $(openssl rand -base64 32)
@@ -49,16 +73,16 @@ jobs:
               env:
                 WORKERS_COUNT: 1
           EOM
-          helm upgrade --install redash . --wait --timeout 5m -f test-values.yaml
+          helm upgrade --install redash . --wait --timeout 10m -f test-values.yaml
           sleep 10
           helm test redash
           helm delete redash
-          helm upgrade --install redashup . --wait --timeout 5m -f test-values.yaml
+          helm upgrade --install redashup . --wait --timeout 10m -f test-values.yaml
           kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
           sleep 10
           helm test redashup
           kubectl delete pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=test-connection"
-          helm upgrade --install redashup . --wait --reset-values --timeout 5m -f test-values.yaml
+          helm upgrade --install redashup . --wait --reset-values --timeout 10m -f test-values.yaml
           kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
           sleep 10
           helm test redashup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         k8s:
+          - v1.31
+          - v1.32
           - v1.33
           - v1.34
           - v1.35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0
+
+- Add optional Knative Serving support for the Redash web server via `server.knative.enabled`: the server renders as a Knative Service instead of a Deployment, while worker, scheduler, migrations, PostgreSQL, and Redis stay on standard Kubernetes resources.
+- Skip the chart-managed `ingress` and `service` resources in Knative mode, relying on Knative routing instead. Configure the revision through `server.knative.annotations` and `server.knative.spec`.
+
 ## 4.0.0
 
 **BREAKING CHANGE — PostgreSQL major version upgrade requires manual migration.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add optional Knative Serving support for the Redash web server via `server.knative.enabled`: the server renders as a Knative Service instead of a Deployment, while worker, scheduler, migrations, PostgreSQL, and Redis stay on standard Kubernetes resources.
 - Skip the chart-managed `ingress` and `service` resources in Knative mode, relying on Knative routing instead. Configure the revision through `server.knative.annotations` and `server.knative.spec`.
+- Evaluate `image.tag` as a Helm template expression via `tpl`, so umbrella charts can pass a templated tag and have it resolve at render time. Plain string tags are unchanged.
 
 ### Fixed
 
@@ -14,7 +15,8 @@
 
 ### Changed
 
-- Test the chart against Kubernetes 1.33-1.36 (was 1.31-1.34) and update the documented prerequisite to 1.33+.
+- Test the chart against Kubernetes 1.31-1.36. 1.35 and 1.36 are added to the CI matrix while 1.31 and 1.32 stay covered, so the documented prerequisite remains 1.31+.
+- Fix typos across the documentation and values comments: `depreciated` -> `deprecated`, `overriden`/`overidden` -> `overridden`, `it's own` -> `its own`, `traffuc` -> `traffic`.
 
 ### Upgrade notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 - Final release to support Redash v8.x
 - Redis password is now required
 - Kubernetes minimum version increased to v19.x
-- Helm 2 depreciated, will be removed in a future version
+- Helm 2 deprecated, will be removed in a future version
 - Supports stable Ingress API
 - Add support for SQL Alchemy pool pre-ping configuration
 - Add support for configurable worker pod labels
@@ -272,7 +272,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 ## 2.3.0
 
 - Added externalPostgreSQLSecret / externalRedisSecret
-- Depreciated envSecretName (plan to remove in 3.0.0 chart)
+- Deprecated envSecretName (plan to remove in 3.0.0 chart)
 - Updated docs to make defaults clearer
 
 ## 2.2.0
@@ -306,7 +306,7 @@ kubectl logs -n <namespace> deploy/<release>-redash-server --tail=50
 ## 1.2.0
 
 - Upgrade Redash to 8.0.2.b37747
-- Upgrade PostgreSQL chart (the old version used depreciated APIs) and image tag
+- Upgrade PostgreSQL chart (the old version used deprecated APIs) and image tag
 - Upgrade Redis chart
 
 ## 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,31 @@
 
 ## 4.1.0
 
+### Added
+
 - Add optional Knative Serving support for the Redash web server via `server.knative.enabled`: the server renders as a Knative Service instead of a Deployment, while worker, scheduler, migrations, PostgreSQL, and Redis stay on standard Kubernetes resources.
 - Skip the chart-managed `ingress` and `service` resources in Knative mode, relying on Knative routing instead. Configure the revision through `server.knative.annotations` and `server.knative.spec`.
+
+### Fixed
+
+- Fix `imagePullSecrets` rendering in the server, worker and scheduler pod specs. The whitespace chomping on the surrounding `with` block glued `serviceAccountName` onto the last pull secret entry, so any release that set `imagePullSecrets` failed to render with `mapping values are not allowed in this context`.
+- Give each worker Deployment a distinct `spec.selector`. `redash.selectorLabels` only emitted the chart name and release instance, so the `adhocworker`, `genericworker` and `scheduledworker` Deployments shared one selector and could adopt each other's Pods. The `app.kubernetes.io/component` label moved from `redash.labels` into `redash.selectorLabels`.
+
+### Changed
+
+- Test the chart against Kubernetes 1.33-1.36 (was 1.31-1.34) and update the documented prerequisite to 1.33+.
+
+### Upgrade notes
+
+A Deployment's `spec.selector` is immutable, so the worker selector fix above cannot be applied by `helm upgrade` alone - the upgrade fails with `field is immutable`. Delete the three worker Deployments first, then upgrade:
+
+```bash
+kubectl delete deployment -n <namespace> \
+  <release>-adhocworker <release>-genericworker <release>-scheduledworker
+helm upgrade <release> redash/redash
+```
+
+Deleting the Deployments removes their Pods, and the upgrade recreates both. Queries queued in Redis during the gap are picked up once the new workers start. The server, scheduler and databases are untouched.
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@
 A Deployment's `spec.selector` is immutable, so the worker selector fix above cannot be applied by `helm upgrade` alone - the upgrade fails with `field is immutable`. Delete the three worker Deployments first, then upgrade:
 
 ```bash
-kubectl delete deployment -n <namespace> \
-  <release>-redash-adhocworker <release>-redash-genericworker <release>-redash-scheduledworker
+kubectl get deploy -n <namespace> -l app.kubernetes.io/instance=<release> \
+  -o name | grep worker | xargs kubectl delete -n <namespace>
 helm upgrade <release> redash/redash
 ```
 
-The `-redash-` segment is the chart name; if you set `nameOverride` or `fullnameOverride`, use `kubectl get deploy -l app.kubernetes.io/instance=<release>` to get the actual names first.
+The worker Deployment names are not spelled out here because they vary: `redash.fullname` is `<release>-redash`, but collapses to just `<release>` when the release name already contains `redash`, and changes again under `nameOverride`/`fullnameOverride`. Selecting on the release label covers every case.
 
 Deleting the Deployments removes their Pods, and the upgrade recreates both. Queries queued in Redis during the gap are picked up once the new workers start. The server, scheduler and databases are untouched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ A Deployment's `spec.selector` is immutable, so the worker selector fix above ca
 
 ```bash
 kubectl delete deployment -n <namespace> \
-  <release>-adhocworker <release>-genericworker <release>-scheduledworker
+  <release>-redash-adhocworker <release>-redash-genericworker <release>-redash-scheduledworker
 helm upgrade <release> redash/redash
 ```
+
+The `-redash-` segment is the chart name; if you set `nameOverride` or `fullnameOverride`, use `kubectl get deploy -l app.kubernetes.io/instance=<release>` to get the actual names first.
 
 Deleting the Deployments removes their Pods, and the upgrade recreates both. Queries queued in Redis during the gap are picked up once the new workers start. The server, scheduler and databases are untouched.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A single community Helm chart (`charts/redash`) that deploys [Redash](https://github.com/getredash/redash) on Kubernetes. There is no application code here — everything is Helm templates, values, and generated docs. Upstream is `github.com/getredash/contrib-helm-chart`; the published repo index lives on the `gh-pages` branch.
+
+## Commands
+
+Dependencies must be fetched before `helm template`/`install` will work (`helm lint` only warns):
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+cd charts/redash && helm dependency build .
+```
+
+```bash
+helm lint charts/redash                 # required to pass by CONTRIBUTING
+helm template test charts/redash        # renders fine with stock values.yaml
+```
+
+Nothing gates rendering with default values — `values.yaml` ships placeholder `redash.secretKey: test` / `cookieSecret: test`, and the `required` guard in `NOTES.txt` is effectively defanged (its `or` chain falls through to the empty `externalPostgreSQLSecret` dict, and `required` only rejects nil and the empty string, so `{}` passes). Values are required for a *working install*, not for rendering. The canonical minimal working value set is the `test-values.yaml` heredoc in `.github/workflows/ci.yml`.
+
+Full functional test = the minikube flow in `.github/workflows/ci.yml` (install → `helm test` → delete → reinstall → upgrade → `helm test`, across four Kubernetes minor versions). To reproduce one iteration locally you need a cluster; then follow that same sequence.
+
+Regenerating the chart README (see the trap below):
+
+```bash
+cd charts/redash && helm-docs --dry-run | prettier --parser markdown > README.md
+```
+
+## Docs are generated — do not hand-edit
+
+`charts/redash/README.md` is produced from `charts/redash/README.md.gotmpl` plus the `# key -- description` comments in `values.yaml`. Edit the source, then regenerate.
+
+Two traps:
+
+- **The pre-commit hook is wrong for the current layout.** `.pre-commit-config.yaml` runs `helm-docs --dry-run > README.md` from the repo root, but the chart moved out of the top level, so that writes the *root* README rather than `charts/redash/README.md`. Run helm-docs from inside `charts/redash`.
+- **The checked-in chart README is stale.** It says version 3.2.0 (Chart.yaml is 4.0.1) and still documents the `postgresqlMigration` block that 4.0.0 removed.
+
+The root `README.md` deliberately uses absolute GitHub URLs because it is synced to `gh-pages`. `templates/` is in `.prettierignore`.
+
+## Release mechanics
+
+`charts/redash/Chart.yaml` `version` must be bumped in every change that should be published — the `chart-releaser` job only runs on pushes to `master` and only publishes versions it hasn't seen (commit `a56f7a8` exists purely to bump the version and trigger it). Chart version is independent of `appVersion` (the Redash release); it follows semver on its own. Breaking changes go in `CHANGELOG.md` and in the "Upgrading" section of `README.md.gotmpl`.
+
+## Architecture
+
+Five workloads render from one shared env helper:
+
+- `server-deployment.yaml` — the web server, fronted by `service.yaml` / optional `ingress.yaml`.
+- `worker-deployment.yaml` — **one Deployment per key under `workers.*`** (`adhoc`, `scheduled`, `generic`), produced by a single `range`. Each worker's config is `mergeOverwrite (deepCopy .Values.worker) $config`, so `worker.*` holds shared defaults and `workers.<name>.*` overrides them. Adding a worker means adding a values key, not a template.
+- `scheduler-deployment.yaml` — `strategy: Recreate`, single instance.
+- `hook-migrations-job.yaml` — a `post-install,post-upgrade` hook Job running `create_db`; this is how schema migrations happen.
+- `tests/test-connection.yaml` — the `helm test` pod, curls the service and greps for "Welcome to Redash".
+
+### `redash.env` in `_helpers.tpl`
+
+An ~80-entry block mapping `redash.*` values to `REDASH_*` env vars, shared by every component. Key points:
+
+- The block is delimited by `## Start primary Redash configuration` / `## End primary Redash configuration` markers that mirror the same markers in `values.yaml` and `secrets.yaml`. Keep the three in sync.
+- `CONTRIBUTING.md` says to regenerate this with `python scripts/update-env-config.py` — **that script no longer exists in the repo**. Adding a Redash setting today means hand-editing `values.yaml` (with its helm-docs comment) and `_helpers.tpl`, plus `secrets.yaml` if the value is a secret.
+- Secret-valued settings are additionally gated on `redash.selfManagedSecrets` and `redash.existingSecret`; follow the existing `{{- if not .Values.redash.selfManagedSecrets }}` pattern rather than inventing a new one.
+- Per-component env reaches the shared helper via `$envCtx := mergeOverwrite (deepCopy .) (dict "Values" (dict "env" .Values.<component>.env))` — the helper always reads `.Values.env`, and each template swaps in its own component env before including it.
+
+### The connection-string snippet is duplicated 4×
+
+When the bundled `postgresql` / `redis` subcharts are enabled, `REDASH_DATABASE_URL` and `REDASH_REDIS_URL` are assembled from their component parts by an inline `/bin/sh -c` block in the container `args`. That identical snippet appears in **server, worker, scheduler, and migrations** templates. Any change to connection handling must be applied to all four.
+
+## Conventions and gotchas
+
+- `Chart.yaml` is `apiVersion: v1` with a separate `requirements.yaml`/`requirements.lock`. This is the legacy Helm 2 layout but still supported and intentional — don't "modernize" it to `apiVersion: v2` with inline `dependencies` without a deliberate decision.
+- Subchart versions use caret ranges (`^18.2.0`), so `requirements.lock` drifts from `requirements.yaml`; regenerate the lock with `helm dependency update`.
+- There is no `values.schema.json`. What validation exists is `required` calls inside templates (`secrets.yaml`, `NOTES.txt`).
+- `redash.fullname` truncates at 43 chars, not the usual 63, to leave room for the component suffixes appended by `redash.worker.fullname` and friends.
+- `extraObjects` (rendered by `extra-manifests.yaml`) accepts raw manifests as strings or maps and runs them through `tpl`, so entries may contain Helm template syntax.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cd charts/redash && helm-docs --dry-run | prettier --parser markdown > README.md
 Two traps:
 
 - **The pre-commit hook is wrong for the current layout.** `.pre-commit-config.yaml` runs `helm-docs --dry-run > README.md` from the repo root, but the chart moved out of the top level, so that writes the *root* README rather than `charts/redash/README.md`. Run helm-docs from inside `charts/redash`.
-- **The checked-in chart README is stale.** It says version 3.2.0 (Chart.yaml is 4.0.1) and still documents the `postgresqlMigration` block that 4.0.0 removed.
+- **Regenerate from `charts/redash`, and check the diff.** The README had drifted from the template before (a stale version line, plus value rows for the `postgresqlMigration` block 4.0.0 removed), because the hook above was writing to the wrong file. Content hand-added to the generated README is silently lost on the next regeneration — the `### From 3.1 to 3.2` upgrade notes had to be moved into `README.md.gotmpl` to survive.
 
 The root `README.md` deliberately uses absolute GitHub URLs because it is synced to `gh-pages`. `templates/` is in `.prettierignore`.
 

--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 4.0.1
+version: 4.1.0
 appVersion: 25.8.0
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -8,14 +8,14 @@ This chart bootstraps a [Redash](https://github.com/getredash/redash) deployment
 
 This is a contributed project developed by volunteers and not officially supported by Redash.
 
-Current chart version is `3.2.0`
+Current chart version is `4.1.0`
 
 * <https://github.com/getredash/redash>
 
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.31+ - chart is tested with latest 4 stable versions (1.31-1.34)
+- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
 - Helm 3 (Helm 2 depreciated)
 - PV provisioner support in the underlying infrastructure
 
@@ -52,6 +52,14 @@ $ helm upgrade --install -f my-values.yaml my-release redash/redash
 The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
+
+## Knative Serving
+
+Set `server.knative.enabled=true` to render the Redash web server as a Knative Service instead of a Kubernetes Deployment. Workers, scheduler, migrations, PostgreSQL, and Redis still render as standard Kubernetes resources.
+
+When Knative mode is enabled, the chart-managed `ingress` and `service` resources are skipped and Knative handles routing instead. Configure autoscaling through `server.knative.annotations`, including `autoscaling.knative.dev/*` keys such as `min-scale` and `max-scale`, and set revision fields such as `containerConcurrency` or `timeoutSeconds` through `server.knative.spec`.
+
+Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
 
 ## Uninstalling the Chart
 
@@ -117,9 +125,6 @@ The following table lists the configurable parameters of the Redash chart and th
 | postgresql.auth.username | string | `"redash"` | PostgreSQL username for redash user (when postgresql chart enabled) |
 | postgresql.enabled | bool | `true` | Whether to deploy a PostgreSQL server to satisfy the applications database requirements. To use an external PostgreSQL set this to false and configure the externalPostgreSQL parameter. |
 | postgresql.primary.service.ports.postgresql | int | `5432` |  |
-| postgresqlMigration.enabled | bool | `false` | Enable automatic PostgreSQL migration hooks for major version upgrades (e.g., 15→18).  WARNING: Requires a PVC to be created beforehand for storing the dump between pre-upgrade and post-upgrade hooks. Create a PVC: kubectl create -f - <<EOF apiVersion: v1 kind: PersistentVolumeClaim metadata:   name: <release-name>-postgres-migration spec:   accessModes: [ReadWriteOnce]   resources:     requests:       storage: 10Gi EOF Then set postgresqlMigration.storage.pvcName to the PVC name. |
-| postgresqlMigration.storage | object | `{"pvcName":""}` | Storage configuration for migration dumps |
-| postgresqlMigration.storage.pvcName | string | `""` | REQUIRED: Name of existing PVC to use for storing migration dumps.  The PVC must exist before running the upgrade. Both pre-upgrade (dump) and post-upgrade (restore) hooks use this PVC. If not set, uses emptyDir which will NOT persist between hooks (migration will fail). |
 | redash.additionalDestinations | string | `""` | `REDASH_ADDITIONAL_DESTINATIONS` value. Comma-separated list of non-default alert destinations to be enabled. |
 | redash.additionalQueryRunners | string | `""` | `REDASH_ADDITIONAL_QUERY_RUNNERS` value. Comma-separated list of non-default query runners to be enabled. |
 | redash.adhocQueryTimeLimit | string | None | `REDASH_ADHOC_QUERY_TIME_LIMIT` value. Time limit for adhoc queries (in seconds). |
@@ -229,6 +234,9 @@ The following table lists the configurable parameters of the Redash chart and th
 | server.env | object | `{}` | Redash server specific environment variables Don't use this for variables that are in the configuration above, however. |
 | server.httpPort | int | `5000` | Server container port (only useful if you are using a customized image) |
 | server.initContainers | list | `[]` | Server init containers configuration |
+| server.knative.annotations | object | `{}` | Annotations for the Knative revision template, including `autoscaling.knative.dev/*` settings |
+| server.knative.enabled | bool | `false` | Render the server as a Knative Service instead of a Deployment |
+| server.knative.spec | object | `{}` | Additional fields for the Knative revision spec (e.g. `containerConcurrency`, `timeoutSeconds`) |
 | server.livenessProbe | object | `{"failureThreshold":10,"initialDelaySeconds":90,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Server liveness probe configuration |
 | server.nodeSelector | object | `{}` | Node labels for server pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/) |
 | server.podAnnotations | object | `{}` | Annotations for server pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -15,8 +15,8 @@ Current chart version is `4.1.0`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
-- Helm 3 (Helm 2 depreciated)
+- Kubernetes 1.31+ - chart is tested with latest 6 stable versions (1.31-1.36)
+- Helm 3 (Helm 2 deprecated)
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -49,7 +49,7 @@ Install the chart:
 $ helm upgrade --install -f my-values.yaml my-release redash/redash
 ```
 
-The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
+The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -251,7 +251,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | server.volumeMounts | list | `[]` | VolumeMounts for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | server.volumes | list | `[]` | Volumes for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | service.annotations | object | `{}` | Annotations to add to the service |
-| service.externalTrafficPolicy | string | `""` |  |
+| service.externalTrafficPolicy | string | `""` | external traffic policy for Load Balancer |
 | service.loadBalancerIP | string | `nil` | Specific IP address to use for cloud providers such as Azure Kubernetes Service [ref](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) |
 | service.port | int | `80` | Service external port |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
@@ -395,21 +395,21 @@ If you prefer manual control:
 - The Redash version is updated from v8 to v10 (v9 never had a stable release)
 - The upgrade should be automatic, but please test on a staging environment first!
 - There are now additional "genericworker" and "scheduler" deployments, with associated configuration in values.yaml
-- 3.x and higher will not run with Redash v8 - if you have overriden the image you will need to update that
+- 3.x and higher will not run with Redash v8 - if you have overridden the image you will need to update that
 - This chart now requires Kubernetes 1.19+
-- Helm 2 is now depreciated and support will be removed in a future version
+- Helm 2 is now deprecated and support will be removed in a future version
 
 ### From 1.x to 2.x
 
 - There are 3 required secrets (see above) that must now be specified in your release
-- The server.env is now depreciated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
+- The server.env is now deprecated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
 
 ### From pre-release to 1.x
 
 - The values.yaml structure has several changes
 - The Redash, PostgreSQL and Redis versions have all been updated
 - Due to these changes you will likely need to dump the database and reload it into a fresh install
-- The chart now has it's own repo: https://getredash.github.io/contrib-helm-chart/
+- The chart now has its own repo: https://getredash.github.io/contrib-helm-chart/
 
 ## License
 

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -86,6 +86,7 @@ The following table lists the configurable parameters of the Redash chart and th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| clusterDomain | string | `"cluster.local"` | Kubernetes cluster domain, used to build in-cluster hostnames |
 | commonLabels | object | `{}` |  |
 | env | object | `{"PYTHONUNBUFFERED":0,"REDASH_PRODUCTION":"true"}` | Redash global environment variables - applied to both server and worker containers. |
 | externalPostgreSQL | string | `nil` | External PostgreSQL configuration. To use an external PostgreSQL instead of the automatically deployed postgresql chart: set postgresql.enabled to false then uncomment and configure the externalPostgreSQL connection URL (e.g. postgresql://user:pass@host:5432/database) |

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -15,7 +15,7 @@ Current chart version is `{{ template "chart.version" . }}`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.19+ - chart is tested with latest 3 stable versions
+- Kubernetes 1.31+ - chart is tested with latest 4 stable versions (1.31-1.34)
 - Helm 3 (Helm 2 depreciated)
 - PV provisioner support in the underlying infrastructure
 
@@ -52,6 +52,14 @@ $ helm upgrade --install -f my-values.yaml my-release redash/redash
 The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
+
+## Knative Serving
+
+Set `server.knative.enabled=true` to render the Redash web server as a Knative Service instead of a Kubernetes Deployment. Workers, scheduler, migrations, PostgreSQL, and Redis still render as standard Kubernetes resources.
+
+When Knative mode is enabled, the chart-managed `ingress` and `service` resources are skipped and Knative handles routing instead. Configure autoscaling through `server.knative.annotations`, including `autoscaling.knative.dev/*` keys such as `min-scale` and `max-scale`, and set revision fields such as `containerConcurrency` or `timeoutSeconds` through `server.knative.spec`.
+
+Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
 
 ## Uninstalling the Chart
 

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -16,7 +16,7 @@ Current chart version is `{{ template "chart.version" . }}`
 
 - At least 3 GB of RAM available on your cluster
 - Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
-- Helm 3 (Helm 2 depreciated)
+- Helm 3 (Helm 2 deprecated)
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -49,7 +49,7 @@ Install the chart:
 $ helm upgrade --install -f my-values.yaml my-release redash/redash
 ```
 
-The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
+The command deploys Redash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section and default [values.yaml](values.yaml) lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -196,21 +196,21 @@ If you prefer manual control:
 - The Redash version is updated from v8 to v10 (v9 never had a stable release)
 - The upgrade should be automatic, but please test on a staging environment first!
 - There are now additional "genericworker" and "scheduler" deployments, with associated configuration in values.yaml
-- 3.x and higher will not run with Redash v8 - if you have overriden the image you will need to update that 
+- 3.x and higher will not run with Redash v8 - if you have overridden the image you will need to update that
 - This chart now requires Kubernetes 1.19+
-- Helm 2 is now depreciated and support will be removed in a future version
+- Helm 2 is now deprecated and support will be removed in a future version
 
 ### From 1.x to 2.x
 
 - There are 3 required secrets (see above) that must now be specified in your release
-- The server.env is now depreciated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
+- The server.env is now deprecated (except for non-standard variables such as PYTHON_*) to allow for better management of Redash configuration and secret values - any existing configuration should be migrated to the new values
 
 ### From pre-release to 1.x
 
 - The values.yaml structure has several changes
 - The Redash, PostgreSQL and Redis versions have all been updated
 - Due to these changes you will likely need to dump the database and reload it into a fresh install
-- The chart now has it's own repo: https://getredash.github.io/contrib-helm-chart/
+- The chart now has its own repo: https://getredash.github.io/contrib-helm-chart/
 
 ## License
 

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -15,7 +15,7 @@ Current chart version is `{{ template "chart.version" . }}`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.31+ - chart is tested with latest 4 stable versions (1.31-1.34)
+- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
 - Helm 3 (Helm 2 depreciated)
 - PV provisioner support in the underlying infrastructure
 
@@ -105,6 +105,91 @@ Below are notes on manual configuration changes or steps needed for major chart 
   - default config for all workers is at `worker` section
 - replaced `hookInstallJob` and `hookUpgradeJob` with `migrations`
 - Moved custom entrypoint scripts to [Redash repo](https://github.com/getredash/redash/pull/6674)
+
+### From 3.1 to 3.2
+
+**CRITICAL: PostgreSQL Major Version Upgrade (15→18)**
+
+This upgrade includes a PostgreSQL major version upgrade from 15 to 18. **PostgreSQL major versions are NOT data-directory compatible** - PostgreSQL 18 cannot read PostgreSQL 15 data directly.
+
+**Two upgrade options:**
+
+#### Option 1: Automatic Migration (Recommended)
+
+Enable automatic migration hooks:
+
+1. **Create a PVC for migration storage** (required):
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: v1
+   kind: PersistentVolumeClaim
+   metadata:
+     name: <release-name>-postgres-migration
+   spec:
+     accessModes: [ReadWriteOnce]
+     resources:
+       requests:
+         storage: 10Gi
+   EOF
+   ```
+
+2. **Enable migration hooks** in your values:
+   ```yaml
+   postgresqlMigration:
+     enabled: true
+     storage:
+       pvcName: <release-name>-postgres-migration
+   ```
+
+3. **Upgrade**:
+   ```bash
+   helm upgrade --reuse-values <release-name> redash/redash
+   ```
+
+**What happens automatically:**
+- Pre-upgrade hook: Dumps PostgreSQL 15 data to the migration PVC
+- Pre-upgrade hook: Scales down PostgreSQL 15 StatefulSet
+- Pre-upgrade hook: Deletes the old PostgreSQL 15 PVC (data is safely backed up)
+- Helm upgrade: Starts PostgreSQL 18 with a fresh data directory
+- Post-upgrade hook: Restores data from dump files to PostgreSQL 18
+
+**Important Notes:**
+- The service account needs RBAC permissions (automatically created when `postgresqlMigration.enabled: true`)
+- Ensure the migration PVC has sufficient storage (at least 2x your database size)
+- The old PostgreSQL 15 PVC will be **deleted** - all data must be in the dump files
+- Test in a staging environment first!
+
+#### Option 2: Manual Migration
+
+If you prefer manual control:
+
+1. **Dump the database**:
+   ```bash
+   kubectl exec -it <release-name>-postgresql-0 -- pg_dump -U redash -d redash -F c -f /tmp/redash-backup.dump
+   kubectl cp <release-name>-postgresql-0:/tmp/redash-backup.dump ./redash-backup.dump
+   ```
+
+2. **Delete the PostgreSQL StatefulSet and PVC**:
+   ```bash
+   kubectl scale statefulset <release-name>-postgresql --replicas=0
+   kubectl delete pvc <release-name>-postgresql-data-0  # or appropriate PVC name
+   ```
+
+3. **Upgrade the chart** (PostgreSQL 18 will start fresh):
+   ```bash
+   helm upgrade --reuse-values <release-name> redash/redash
+   ```
+
+4. **Wait for PostgreSQL 18 to be ready**, then restore:
+   ```bash
+   kubectl cp ./redash-backup.dump <release-name>-postgresql-0:/tmp/redash-backup.dump
+   kubectl exec -it <release-name>-postgresql-0 -- pg_restore -U redash -d redash -v --no-owner --no-privileges /tmp/redash-backup.dump
+   ```
+
+**Other changes:**
+- Redash upgraded from v24.04.0-dev to v25.8.0 (latest stable)
+- Redis dependency upgraded from ^19.1.0 to ^24.1.0
+- Kubernetes compatibility: 1.31+ (removed support for 1.26-1.30)
 
 ### From 2.x to 3.x
 

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -15,7 +15,7 @@ Current chart version is `{{ template "chart.version" . }}`
 ## Prerequisites
 
 - At least 3 GB of RAM available on your cluster
-- Kubernetes 1.33+ - chart is tested with latest 4 stable versions (1.33-1.36)
+- Kubernetes 1.31+ - chart is tested with latest 6 stable versions (1.31-1.36)
 - Helm 3 (Helm 2 deprecated)
 - PV provisioner support in the underlying infrastructure
 

--- a/charts/redash/templates/NOTES.txt
+++ b/charts/redash/templates/NOTES.txt
@@ -1,5 +1,8 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.server.knative.enabled }}
+  export SERVICE_URL=$(kubectl get --namespace {{ .Release.Namespace }} services.serving.knative.dev {{ include "redash.fullname" . }} -o jsonpath="{.status.url}")
+  echo $SERVICE_URL
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -516,9 +516,6 @@ Common labels
 {{- define "redash.labels" -}}
 helm.sh/chart: {{ include "redash.chart" . }}
 {{ include "redash.selectorLabels" . }}
-{{- with .workerName }}
-app.kubernetes.io/component: {{ . }}worker
-{{- end }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
@@ -534,6 +531,9 @@ Selector labels
 {{- define "redash.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "redash.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .workerName }}
+app.kubernetes.io/component: {{ . }}worker
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -511,6 +511,19 @@ Environment variables initialized from secret used across each component.
 {{- end -}}
 
 {{/*
+Render a probe. The chart's default handler is merged in only when the caller has
+not supplied one of its own, so a custom exec/tcpSocket probe does not end up
+alongside the default httpGet.
+*/}}
+{{- define "redash.probe" -}}
+{{- $probe := deepCopy .probe -}}
+{{- if not (or $probe.exec $probe.httpGet $probe.tcpSocket $probe.grpc) -}}
+{{- $probe = mergeOverwrite (deepCopy .default) $probe -}}
+{{- end -}}
+{{- toYaml $probe -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "redash.labels" -}}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -511,13 +511,17 @@ Environment variables initialized from secret used across each component.
 {{- end -}}
 
 {{/*
-Render a probe. The chart's default handler is merged in only when the caller has
-not supplied one of its own, so a custom exec/tcpSocket probe does not end up
-alongside the default httpGet.
+Render a probe against the chart's default handler.
+
+The default is deep-merged in, so a partial override (e.g. httpGet.path alone)
+still inherits httpGet.port. It is suppressed only when the caller supplies a
+different kind of handler, which would otherwise leave the probe with two
+handlers -- rejected by the API server. Merging into a copy keeps the caller's
+default untouched for the next probe.
 */}}
 {{- define "redash.probe" -}}
 {{- $probe := deepCopy .probe -}}
-{{- if not (or $probe.exec $probe.httpGet $probe.tcpSocket $probe.grpc) -}}
+{{- if not (or $probe.exec $probe.tcpSocket $probe.grpc) -}}
 {{- $probe = mergeOverwrite (deepCopy .default) $probe -}}
 {{- end -}}
 {{- toYaml $probe -}}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -517,7 +517,7 @@ Common labels
 helm.sh/chart: {{ include "redash.chart" . }}
 {{ include "redash.selectorLabels" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ tpl (toString (.Values.image.tag | default .Chart.AppVersion)) . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.commonLabels }}

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - name: {{ include "redash.name" . }}-server
         securityContext: {{ toYaml .Values.migrations.securityContext | nindent 10 }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ tpl (toString (.Values.image.tag | default .Chart.AppVersion)) . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         {{- if or .Values.redis.enabled .Values.postgresql.enabled }}

--- a/charts/redash/templates/ingress.yaml
+++ b/charts/redash/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.server.knative.enabled) -}}
 {{- $fullName := include "redash.fullname" . -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end }}
         - name: {{ include "redash.name" . }}-scheduler
           securityContext: {{ toYaml .Values.scheduler.securityContext | nindent 12 }}
-          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ tpl (toString (.Values.image.tag | default .Chart.AppVersion)) . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $volumeMounts := concat .Values.volumeMounts .Values.scheduler.volumeMounts }}
           {{- with $volumeMounts }}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -25,9 +25,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with .Values.imagePullSecrets -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.scheduler.podSecurityContext | nindent 8 }}
       {{- $initContainers := concat .Values.initContainers .Values.scheduler.initContainers }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -23,9 +23,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with .Values.imagePullSecrets -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext: {{ toYaml .Values.server.podSecurityContext | nindent 8 }}
       {{- $initContainers := concat .Values.initContainers .Values.server.initContainers }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -74,10 +74,10 @@ spec:
             - containerPort: {{ .Values.server.httpPort }}
           {{- $defaultProbe := dict "httpGet" (dict "path" "/ping" "port" .Values.server.httpPort) -}}
           {{- with .Values.server.livenessProbe }}
-          livenessProbe: {{ deepCopy . | mergeOverwrite $defaultProbe | toYaml | nindent 12 }}
+          livenessProbe: {{ include "redash.probe" (dict "probe" . "default" $defaultProbe) | nindent 12 }}
           {{- end }}
           {{- with .Values.server.readinessProbe }}
-          readinessProbe: {{ deepCopy . | mergeOverwrite $defaultProbe | toYaml | nindent 12 }}
+          readinessProbe: {{ include "redash.probe" (dict "probe" . "default" $defaultProbe) | nindent 12 }}
           {{- end }}
           {{- with .Values.server.resources }}
           resources: {{ toYaml . | nindent 12 }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
         - name: {{ include "redash.name" . }}-server
           securityContext: {{ toYaml .Values.server.securityContext | nindent 12 }}
-          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ tpl (toString (.Values.image.tag | default .Chart.AppVersion)) . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $volumeMounts := concat .Values.volumeMounts .Values.server.volumeMounts }}
           {{- with $volumeMounts }}

--- a/charts/redash/templates/server-knative-service.yaml
+++ b/charts/redash/templates/server-knative-service.yaml
@@ -76,10 +76,10 @@ spec:
             - containerPort: {{ .Values.server.httpPort }}
           {{- $defaultProbe := dict "httpGet" (dict "path" "/ping" "port" .Values.server.httpPort) -}}
           {{- with .Values.server.livenessProbe }}
-          livenessProbe: {{ deepCopy . | mergeOverwrite $defaultProbe | toYaml | nindent 12 }}
+          livenessProbe: {{ include "redash.probe" (dict "probe" . "default" $defaultProbe) | nindent 12 }}
           {{- end }}
           {{- with .Values.server.readinessProbe }}
-          readinessProbe: {{ deepCopy . | mergeOverwrite $defaultProbe | toYaml | nindent 12 }}
+          readinessProbe: {{ include "redash.probe" (dict "probe" . "default" $defaultProbe) | nindent 12 }}
           {{- end }}
           {{- with .Values.server.resources }}
           resources: {{ toYaml . | nindent 12 }}

--- a/charts/redash/templates/server-knative-service.yaml
+++ b/charts/redash/templates/server-knative-service.yaml
@@ -41,7 +41,7 @@ spec:
           {{- with .Values.server.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
-          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ tpl (toString (.Values.image.tag | default .Chart.AppVersion)) . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $volumeMounts := concat .Values.volumeMounts .Values.server.volumeMounts }}
           {{- with $volumeMounts }}

--- a/charts/redash/templates/server-knative-service.yaml
+++ b/charts/redash/templates/server-knative-service.yaml
@@ -1,17 +1,12 @@
-{{- if not .Values.server.knative.enabled -}}
-apiVersion: apps/v1
-kind: Deployment
+{{- if .Values.server.knative.enabled -}}
+apiVersion: serving.knative.dev/v1
+kind: Service
 metadata:
   name: {{ include "redash.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
 spec:
-  replicas: {{ .Values.server.replicaCount }}
-  selector:
-    matchLabels:
-      {{- include "redash.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: server
   template:
     metadata:
       labels:
@@ -20,15 +15,20 @@ spec:
         {{- with .Values.server.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- with .Values.server.podAnnotations }}
+      {{- with mergeOverwrite (deepCopy .Values.server.podAnnotations) .Values.server.knative.annotations }}
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{ with .Values.imagePullSecrets -}}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      {{ end -}}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
-      securityContext: {{ toYaml .Values.server.podSecurityContext | nindent 8 }}
+      {{- with .Values.server.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.knative.spec }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- $initContainers := concat .Values.initContainers .Values.server.initContainers }}
       {{- with $initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
@@ -38,7 +38,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: {{ include "redash.name" . }}-server
-          securityContext: {{ toYaml .Values.server.securityContext | nindent 12 }}
+          {{- with .Values.server.securityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image.registry }}/{{ .Values.image.repo }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $volumeMounts := concat .Values.volumeMounts .Values.server.volumeMounts }}

--- a/charts/redash/templates/server-knative-service.yaml
+++ b/charts/redash/templates/server-knative-service.yaml
@@ -19,9 +19,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with .Values.imagePullSecrets -}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       {{- with .Values.server.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}

--- a/charts/redash/templates/service.yaml
+++ b/charts/redash/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.server.knative.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -24,3 +25,4 @@ spec:
   selector:
     {{- include "redash.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: server
+{{- end }}

--- a/charts/redash/templates/tests/test-connection.yaml
+++ b/charts/redash/templates/tests/test-connection.yaml
@@ -1,7 +1,12 @@
+{{- $fullName := include "redash.fullname" . -}}
+{{- $testUrl := printf "http://%s:%v" $fullName .Values.service.port -}}
+{{- if .Values.server.knative.enabled -}}
+{{- $testUrl = printf "http://%s.%s.svc.cluster.local" $fullName .Release.Namespace -}}
+{{- end -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "redash.fullname" . }}-test-connection"
+  name: "{{ $fullName }}-test-connection"
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: test-connection
@@ -12,5 +17,5 @@ spec:
     - name: curl
       image: curlimages/curl:8.8.0
       command: ['sh']
-      args: ['-c', 'curl --silent --show-error -L --max-redirs 3 --retry 3 --retry-connrefused --retry-delay 10 --max-time 30 "http://{{ include "redash.fullname" . }}:{{ .Values.service.port }}" | fgrep "Welcome to Redash"']
+      args: ['-c', 'curl --silent --show-error -L --max-redirs 3 --retry 3 --retry-connrefused --retry-delay 10 --max-time 30 "{{ $testUrl }}" | fgrep "Welcome to Redash"']
   restartPolicy: Never

--- a/charts/redash/templates/tests/test-connection.yaml
+++ b/charts/redash/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 {{- $fullName := include "redash.fullname" . -}}
 {{- $testUrl := printf "http://%s:%v" $fullName .Values.service.port -}}
 {{- if .Values.server.knative.enabled -}}
-{{- $testUrl = printf "http://%s.%s.svc.cluster.local" $fullName .Release.Namespace -}}
+{{- $testUrl = printf "http://%s.%s.svc.%s" $fullName .Release.Namespace .Values.clusterDomain -}}
 {{- end -}}
 apiVersion: v1
 kind: Pod

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         - name: {{ include "redash.name" $context }}-{{ $workerName }}worker
           securityContext: {{ toYaml $workerConfig.securityContext | nindent 12 }}
-          image: {{ $.Values.image.registry }}/{{ $.Values.image.repo }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}
+          image: {{ $.Values.image.registry }}/{{ $.Values.image.repo }}:{{ tpl (toString ($.Values.image.tag | default $.Chart.AppVersion)) $ }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           args:
           {{- if or $.Values.redis.enabled $.Values.postgresql.enabled }}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -22,9 +22,9 @@ spec:
       annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
-      {{ with $.Values.imagePullSecrets -}}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 8 }}
-      {{- end -}}
+      {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" $context }}
       securityContext: {{ toYaml $workerConfig.podSecurityContext | nindent 8 }}
       {{- with concat $.Values.initContainers $workerConfig.initContainers }}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -303,6 +303,14 @@ server:
   # server.replicaCount -- Number of server pods to run
   replicaCount: 1
 
+  knative:
+    # server.knative.enabled -- Render the server as a Knative Service instead of a Deployment
+    enabled: false
+    # server.knative.annotations -- Annotations for the Knative revision template, including `autoscaling.knative.dev/*` settings
+    annotations: {}
+    # server.knative.spec -- Additional fields for the Knative revision spec (e.g. `containerConcurrency`, `timeoutSeconds`)
+    spec: {}
+
   # server.resources -- Server resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
   resources:
     {}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -373,7 +373,7 @@ service:
   loadBalancerIP:
   # service.type -- Kubernetes Service type
   type: ClusterIP
-  # service.externalTraffucPolicy -- external traffic policy for Load Balancer
+  # service.externalTrafficPolicy -- external traffic policy for Load Balancer
   externalTrafficPolicy: ""
   # service.port -- Service external port
   port: 80
@@ -419,7 +419,7 @@ workers:
       QUEUES: periodic,emails,default
       WORKERS_COUNT: 1
 
-## Common worker configuration, which can be overidden for each worker at workers.<workerName>
+## Common worker configuration, which can be overridden for each worker at workers.<workerName>
 worker:
   # worker.replicaCount -- Default number of worker pods to run
   replicaCount: 1
@@ -587,7 +587,7 @@ externalPostgreSQLSecret:
   # name: redash-postgres
   # key: connectionString
 
-# envSecretName -- DEPRECIATED, use externalPostgreSQLSecret/externalRedisSecret instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
+# envSecretName -- DEPRECATED, use externalPostgreSQLSecret/externalRedisSecret instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
 # envSecretName:
 
 ## Configuration values for the postgresql dependency. This PostgreSQL instance is used by default for all Redash state storage [ref](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md)

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -32,6 +32,9 @@ volumeMounts: []
 # commonLabels -- Redash global labels -- applied to all objects
 commonLabels: {}
 
+# clusterDomain -- Kubernetes cluster domain, used to build in-cluster hostnames
+clusterDomain: cluster.local
+
 ## Service account and security context configuration
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created


### PR DESCRIPTION
Consolidates six open PRs into one 4.1.0 release. They overlap in `Chart.yaml`, `README.md.gotmpl`, `_helpers.tpl` and the deployment templates, so they cannot be merged independently without conflicts.

Supersedes and closes #209, #210, #211, #212, #213, #214. Each is a separate commit with the original author credited via `Co-authored-by`.

## What's included

| PR | Author | Change |
|----|--------|--------|
| #211 | @braun1928 | Fix `imagePullSecrets` rendering in the server, worker and scheduler pod specs |
| #212 | @kahirokunn | Give each worker Deployment a distinct `spec.selector` |
| #213 | @kahirokunn | Optional Knative Serving support for the web server |
| #214 | @kahirokunn | Add Kubernetes 1.35 / 1.36 to the CI matrix |
| #209 | @likesavabutworse | Evaluate `image.tag` as a Helm template expression |
| #210 | @shubhamg931 | Fix documentation typos |

Plus one change of its own: **1.31 and 1.32 stay in the CI matrix.** #214 swapped them out for 1.35/1.36; this widens the matrix to all six minors instead, so support for the older versions isn't dropped silently. The documented prerequisite stays `1.31+`.

## Overlaps resolved

- **Version:** one `4.1.0` bump instead of #211's `4.0.2` and #213's `4.1.0`. The missing trailing newline in `Chart.yaml` is restored.
- **Prerequisites line:** #210, #213 and #214 all rewrote it. Final text keeps #210's `deprecated` spelling fix and reads `Kubernetes 1.31+ ... (1.31-1.36)`.
- **`imagePullSecrets` and `image.tag` in the Knative template:** #213 was written before #211 and #209, so the new `server-knative-service.yaml` carried the old form of both. Both fixes are applied there too.
- **`_helpers.tpl`:** #209 patches the `app.kubernetes.io/version` label on a line #212 moves. Merged so both land.
- **`charts/redash/README.md`** is regenerated with `helm-docs` rather than hand-patched, which is where #210's fixes to `values.yaml` and `README.md.gotmpl` surface. Regenerating also drops the `postgresqlMigration.*` rows, which document values that no longer exist since 4.0.0.
- **`### From 3.1 to 3.2`** existed only in the generated README, never in `README.md.gotmpl`, so regenerating would have deleted 84 lines of upgrade notes. Moved into the template first.

### One hunk deliberately left out

#209 also rewrote the repo's root `README.md` with the chart's generated docs. That is the result of running `helm-docs` from the repo root, which is where `.pre-commit-config.yaml` still points even though the chart moved out of the top level. Taking it would have replaced the repository landing page. The hook itself is worth fixing separately.

## ⚠️ Upgrade note for #212

A Deployment's `spec.selector` is immutable, so the worker selector fix cannot be applied by `helm upgrade` alone — it fails with `field is immutable`. Existing releases must delete the worker Deployments first:

```bash
kubectl delete deployment -n <namespace> \
  <release>-adhocworker <release>-genericworker <release>-scheduledworker
helm upgrade <release> redash/redash
```

Brief worker downtime; the server, scheduler and databases are untouched. Documented in `CHANGELOG.md`. **Worth deciding whether this warrants `5.0.0` rather than `4.1.0` before merging** — CI won't catch it, because it installs fresh and then upgrades from the same chart version, and merging publishes the version irreversibly via chart-releaser.

## Verification

`helm lint` and `helm template` pass in both default and Knative mode. Rendered manifests were parsed as YAML and asserted:

- With `imagePullSecrets` set, `master` fails to render (`mapping values are not allowed in this context`, `worker-deployment.yaml:25`); this branch renders valid documents with the pull secret on all six pod controllers and on the Knative Service.
- The three worker Deployments render 3 distinct selectors (identical on `master`).
- With `server.knative.enabled=true`, the server Deployment, the chart's Service and the Ingress are all absent, the Knative Service is present, and the `helm test` pod targets the cluster-local URL.
- `image.tag` renders unchanged for a plain string (`v1.2.3`), and a templated value resolves: `{{ "myprefix-" }}123` → `myprefix-123`, `{{ .Chart.AppVersion }}-{{ .Release.Name }}` → `25.8.0-test`, including in Knative mode and in the `app.kubernetes.io/version` label.

Full minikube CI across the six Kubernetes versions runs on this PR.

## Also included

`CLAUDE.md`, documenting the repo layout for Claude Code — the `helm dependency build` prerequisite, the generated-README workflow (including the pre-commit hook path bug noted above), and the chart-releaser version-bump requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
