### PR TITLE
Consolidate PRs #191, #195, #200 into 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.2.0
+
+### Added
+
+- Add `topologySpreadConstraints` for the server, workers, scheduler and migrations job, alongside the existing `nodeSelector`/`affinity`/`tolerations` settings. Workers read the merged per-worker config, so `workers.<name>.topologySpreadConstraints` overrides the shared `worker.topologySpreadConstraints` default.
+- Add `postgresql.auth.existingSecret` and `postgresql.auth.secretKeys.userPasswordKey`, so a release can point the bundled PostgreSQL at an existing secret.
+
+### Fixed
+
+- Emit `SQLALCHEMY_ENABLE_POOL_PRE_PING`. `redash.sqlAlchemyEnablePoolPrePing` was documented and defaulted to `"true"`, but the shared env helper never rendered the variable, so setting it had no effect.
+- Read the database password from `postgresql.auth.existingSecret` when it is set. `REDASH_DATABASE_PASSWORD` was hardcoded to the `password` key of the chart-managed `<release>-postgresql` secret, so a release using an existing secret referenced a secret that does not exist. Default renders are unchanged.
+
 ## 4.1.0
 
 ### Added

--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redash
-version: 4.1.0
+version: 4.2.0
 appVersion: 25.8.0
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -59,7 +59,7 @@ Set `server.knative.enabled=true` to render the Redash web server as a Knative S
 
 When Knative mode is enabled, the chart-managed `ingress` and `service` resources are skipped and Knative handles routing instead. Configure autoscaling through `server.knative.annotations`, including `autoscaling.knative.dev/*` keys such as `min-scale` and `max-scale`, and set revision fields such as `containerConcurrency` or `timeoutSeconds` through `server.knative.spec`.
 
-Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
+Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, `server.topologySpreadConstraints`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
 
 ## Uninstalling the Chart
 

--- a/charts/redash/README.md
+++ b/charts/redash/README.md
@@ -8,7 +8,7 @@ This chart bootstraps a [Redash](https://github.com/getredash/redash) deployment
 
 This is a contributed project developed by volunteers and not officially supported by Redash.
 
-Current chart version is `4.1.0`
+Current chart version is `4.2.0`
 
 * <https://github.com/getredash/redash>
 
@@ -117,12 +117,15 @@ The following table lists the configurable parameters of the Redash chart and th
 | migrations.resources | string | `nil` | Scheduled worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/) |
 | migrations.securityContext | object | `{}` |  |
 | migrations.tolerations | list | `[]` | Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| migrations.topologySpreadConstraints | list | `[]` | Topology spread constraints for migrations pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) |
 | migrations.ttlSecondsAfterFinished | int | `600` | ttl for install job [ref](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) |
 | migrations.volumeMounts | list | `[]` | volume mounts for migrations pods |
 | migrations.volumes | list | `[]` | volumes that will be mounted to migrations pods only |
 | nameOverride | string | `""` |  |
 | postgresql.auth.database | string | `"redash"` | PostgreSQL database name (when postgresql chart enabled) |
+| postgresql.auth.existingSecret | string | `""` | Name of an existing secret holding the PostgreSQL password. Takes precedence over postgresql.auth.password, and is read by both the postgresql subchart and Redash. |
 | postgresql.auth.password | string | `nil` | REQUIRED: PostgreSQL password for redash user (when postgresql chart enabled) |
+| postgresql.auth.secretKeys.userPasswordKey | string | `"password"` | Key inside postgresql.auth.existingSecret holding the redash user password |
 | postgresql.auth.username | string | `"redash"` | PostgreSQL username for redash user (when postgresql chart enabled) |
 | postgresql.enabled | bool | `true` | Whether to deploy a PostgreSQL server to satisfy the applications database requirements. To use an external PostgreSQL set this to false and configure the externalPostgreSQL parameter. |
 | postgresql.primary.service.ports.postgresql | int | `5432` |  |
@@ -229,6 +232,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | scheduler.resources | string | `nil` | scheduler resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/) |
 | scheduler.securityContext | object | `{}` |  |
 | scheduler.tolerations | list | `[]` | Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| scheduler.topologySpreadConstraints | list | `[]` | Topology spread constraints for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) |
 | scheduler.volumeMounts | list | `[]` | VolumeMounts for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | scheduler.volumes | list | `[]` | Volumes for scheduler pod  assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | server.affinity | object | `{}` | Affinity for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
@@ -249,6 +253,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | server.resources | object | `{}` | Server resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/) |
 | server.securityContext | object | `{}` |  |
 | server.tolerations | list | `[]` | Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| server.topologySpreadConstraints | list | `[]` | Topology spread constraints for server pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) |
 | server.volumeMounts | list | `[]` | VolumeMounts for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | server.volumes | list | `[]` | Volumes for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | service.annotations | object | `{}` | Annotations to add to the service |
@@ -273,6 +278,7 @@ The following table lists the configurable parameters of the Redash chart and th
 | worker.resources | string | `nil` | Worker default resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/) |
 | worker.securityContext | object | `{}` |  |
 | worker.tolerations | list | `[]` | Default tolerations for worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| worker.topologySpreadConstraints | list | `[]` | Default topology spread constraints for worker pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) |
 | worker.volumeMounts | list | `[]` | Default VolumeMounts for worker pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | worker.volumes | list | `[]` | Default volumes for pod worker assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | workers.adhoc.env | object | `{"QUEUES":"queries","WORKERS_COUNT":2}` | Redash ad-hoc worker specific environment variables. |

--- a/charts/redash/README.md.gotmpl
+++ b/charts/redash/README.md.gotmpl
@@ -59,7 +59,7 @@ Set `server.knative.enabled=true` to render the Redash web server as a Knative S
 
 When Knative mode is enabled, the chart-managed `ingress` and `service` resources are skipped and Knative handles routing instead. Configure autoscaling through `server.knative.annotations`, including `autoscaling.knative.dev/*` keys such as `min-scale` and `max-scale`, and set revision fields such as `containerConcurrency` or `timeoutSeconds` through `server.knative.spec`.
 
-Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
+Knative mode requires Knative Serving to be available on the target cluster. Some server pod settings use Knative feature-gated PodSpec fields, such as `server.initContainers`, `server.nodeSelector`, `server.affinity`, `server.tolerations`, `server.priorityClassName`, `server.podSecurityContext`, `server.topologySpreadConstraints`, and some `server.volumes` values. Enable the corresponding Knative `config-features` flags before setting those values; otherwise Knative admission rejects the Service and `helm install/upgrade` fails.
 
 ## Uninstalling the Chart
 

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -91,8 +91,8 @@ Shared environment block used across each component.
 - name: REDASH_DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Release.Name }}-postgresql
-      key: password
+      name: {{ .Values.postgresql.auth.existingSecret | default (printf "%s-postgresql" .Release.Name) }}
+      key: {{ ternary .Values.postgresql.auth.secretKeys.userPasswordKey "password" (ne .Values.postgresql.auth.existingSecret "") }}
 - name: REDASH_DATABASE_HOSTNAME
   value: {{ include "redash.postgresql.fullname" . }}
 - name: REDASH_DATABASE_PORT

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -498,6 +498,10 @@ Shared environment block used across each component.
   value: {{ quote . }}
 {{- end }}
 ## End primary Redash configuration
+{{- with .Values.redash.sqlAlchemyEnablePoolPrePing }}
+- name: SQLALCHEMY_ENABLE_POOL_PRE_PING
+  value: {{ quote . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -91,8 +91,8 @@ Shared environment block used across each component.
 - name: REDASH_DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.postgresql.auth.existingSecret | default (printf "%s-postgresql" .Release.Name) }}
-      key: {{ ternary .Values.postgresql.auth.secretKeys.userPasswordKey "password" (ne .Values.postgresql.auth.existingSecret "") }}
+      name: {{ .Values.postgresql.auth.existingSecret | default (printf "%s-postgresql" .Release.Name) | quote }}
+      key: {{ ternary .Values.postgresql.auth.secretKeys.userPasswordKey "password" (ne .Values.postgresql.auth.existingSecret "") | quote }}
 - name: REDASH_DATABASE_HOSTNAME
   value: {{ include "redash.postgresql.fullname" . }}
 - name: REDASH_DATABASE_PORT
@@ -115,9 +115,9 @@ Shared environment block used across each component.
   valueFrom:
     secretKeyRef:
     {{- with .Values.redis.existingSecret }}
-      name: {{ . }}
+      name: {{ . | quote }}
     {{- else }}
-      name: {{ .Release.Name }}-redis
+      name: {{ printf "%s-redis" .Release.Name | quote }}
     {{- end }}
       key: redis-password
 - name: REDASH_REDIS_HOSTNAME

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -79,6 +79,9 @@ spec:
       {{- with .Values.migrations.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.migrations.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.migrations.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -84,6 +84,9 @@ spec:
       {{- with .Values.scheduler.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.scheduler.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.scheduler.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -89,6 +89,9 @@ spec:
       {{- with .Values.server.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.server.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/server-knative-service.yaml
+++ b/charts/redash/templates/server-knative-service.yaml
@@ -91,6 +91,9 @@ spec:
       {{- with .Values.server.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.server.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -80,6 +80,9 @@ spec:
       {{- with $workerConfig.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $workerConfig.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $workerConfig.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -606,6 +606,11 @@ postgresql:
     username: redash
     # postgresql.auth.password -- REQUIRED: PostgreSQL password for redash user (when postgresql chart enabled)
     password:
+    # postgresql.auth.existingSecret -- Name of an existing secret holding the PostgreSQL password. Takes precedence over postgresql.auth.password, and is read by both the postgresql subchart and Redash.
+    existingSecret: ""
+    secretKeys:
+      # postgresql.auth.secretKeys.userPasswordKey -- Key inside postgresql.auth.existingSecret holding the redash user password
+      userPasswordKey: password
   # postgresql.auth.database -- PostgreSQL database name (when postgresql chart enabled)
     database: redash
 

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -348,6 +348,9 @@ server:
   # server.nodeSelector -- Node labels for server pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # server.topologySpreadConstraints -- Topology spread constraints for server pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: []
+
   # server.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -446,6 +449,9 @@ worker:
   # worker.nodeSelector -- Default node labels for worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # worker.topologySpreadConstraints -- Default topology spread constraints for worker pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: []
+
   # worker.tolerations -- Default tolerations for worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -516,6 +522,9 @@ scheduler:
   # scheduler.nodeSelector -- Node labels for scheduler pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
 
+  # scheduler.topologySpreadConstraints -- Topology spread constraints for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: []
+
   # scheduler.tolerations -- Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
 
@@ -565,6 +574,9 @@ migrations:
 
   # migrations.nodeSelector -- Node labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
   nodeSelector: {}
+
+  # migrations.topologySpreadConstraints -- Topology spread constraints for migrations pod assignment [ref](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+  topologySpreadConstraints: []
 
   # migrations.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []


### PR DESCRIPTION
Consolidates the three remaining actionable PRs into a 4.2.0 release. Supersedes and closes #191, #195, #200. Each is a separate commit with the original author credited via `Co-authored-by`.

| PR | Author | Change |
|----|--------|--------|
| #200 | @brianrudolf | Emit `SQLALCHEMY_ENABLE_POOL_PRE_PING` |
| #195 | @seslly | Honor `postgresql.auth.existingSecret` for the database password |
| #191 | @Mason0920 | `topologySpreadConstraints` on all workloads |

## Two of these fix values that silently did nothing

**#200** — `redash.sqlAlchemyEnablePoolPrePing` has been in `values.yaml` with a documented default of `"true"`, but the shared env helper never emitted the variable. Rendered output contained zero occurrences of `SQLALCHEMY_ENABLE_POOL_PRE_PING`, so anyone who set it got nothing. Now emitted across all six workloads.

**#195** — `REDASH_DATABASE_PASSWORD` was hardcoded to the `password` key of `<release>-postgresql`. Pointing the bundled PostgreSQL at an existing secret left Redash referencing a secret that does not exist. The upstream patch referenced `postgresql.auth.secretKeys.userPasswordKey`, which this chart never declared, so the key would have resolved empty when only `existingSecret` was set — both values are now declared and documented.

Verified across all three paths:

| values | rendered `secretKeyRef` |
|---|---|
| default | `{name: test-postgresql, key: password}` (unchanged from master) |
| `existingSecret=my-pg` | `{name: my-pg, key: password}` |
| `+ userPasswordKey=pgpass` | `{name: my-pg, key: pgpass}` |

## #191 was reimplemented, not applied

The upstream patch **made the chart fail to render entirely**:

```
Error: parse error at (redash/templates/worker-deployment.yaml:83): bad character U+0024 '$'
```

It wrote `.Values.$workerConfig.topologySpreadConstraints` — a variable can't be used as a field name. Three further problems: it used `indent 8` where every surrounding block uses `nindent 8` (malformed YAML), declared the value as `{}` though the field is a list, and predated the Knative template.

Reimplemented in the chart's existing style, reading the merged `$workerConfig` so per-worker overrides work:

```
test-redash-adhocworker        maxSkew=9 key=topology.kubernetes.io/zone   <- workers.adhoc override
test-redash-genericworker      maxSkew=1 key=kubernetes.io/hostname        <- worker default
test-redash-scheduledworker    maxSkew=1 key=kubernetes.io/hostname
```

Applied to server, all workers, scheduler, migrations and the Knative Service. Knative gates this PodSpec field, so it needs the corresponding `config-features` flag there.

## Verification

`helm lint` and `helm template` pass in default and Knative mode. Rendered manifests parsed as YAML: 31 documents, `imagePullSecrets` on all 6 pod controllers, 3/3 distinct worker selectors. With no values set, `topologySpreadConstraints` appears zero times — no behaviour change for existing releases. The 4.1.0 probe helper and `clusterDomain` still behave correctly.

No upgrade steps: unlike 4.1.0, nothing here touches an immutable field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getredash/contrib-helm-chart/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

